### PR TITLE
Ignore e2e test

### DIFF
--- a/.travis.yaml
+++ b/.travis.yaml
@@ -14,5 +14,5 @@ before_install:
 script:
   - make test
   - make build.docker
-  - roveralls
+  - roveralls -ignore cmd/e2e
   - goveralls -v -coverprofile=roveralls.coverprofile -service=travis-ci


### PR DESCRIPTION
## Description
roveralls should ignore e2e tests.
We already test those.