### PR TITLE
Prepare first release

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -18,10 +18,12 @@ pipeline:
     cmd: |
       if [[ $CDP_TARGET_BRANCH == master && ! $CDP_PULL_REQUEST_NUMBER ]]; then
         IMAGE=registry-write.opensource.zalan.do/poirot/es-operator
+        VERSION=$(git describe --tags --always --dirty)
       else
         IMAGE=registry-write.opensource.zalan.do/poirot/es-operator-test
+        VERSION=$CDP_BUILD_VERSION
       fi
-      IMAGE=$IMAGE VERSION=$CDP_BUILD_VERSION make build.push
+      IMAGE=$IMAGE VERSION=$VERSION make build.push
 - id: e2e
   type: process
   desc: "E2E Tests"


### PR DESCRIPTION
We will shift from publishing docker images tagged with CDP_BUILD_VERSION to using git SHA, and git tags.

Signed-off-by: Oliver Trosien <oliver.trosien@zalando.de>
