### PR TITLE
Introduce golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+run:
+  concurrency: 4
+  modules-download-mode: readonly
+
+linters-settings:
+  golint:
+      min-confidence: 0.9
+
+  gocyclo:
+      min-complexity: 15
+
+linters:
+  disable-all: true
+  enable:
+    - govet
+    - ineffassign
+    - golint
+    - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,5 @@
 run:
   concurrency: 4
-  modules-download-mode: readonly
 
 linters-settings:
   golint:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
   - "1.12.x"
 
 env:
-- GO111MODULE=on
+- GO111MODULE=on GOLANGCI_RELEASE="v1.16.0"
 
 jobs:
   include:
@@ -13,8 +13,10 @@ jobs:
       before_script:
         - go get github.com/mattn/goveralls
         - go get github.com/lawrencewoodman/roveralls
+        - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_RELEASE}
       script:
         - make test
+        - make lint
         - make build.docker
         - roveralls -ignore cmd/e2e
         - goveralls -v -coverprofile=roveralls.coverprofile -service=travis-ci

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ check:
 	golint $(GOPKGS)
 	go vet -v $(GOPKGS)
 
+lint:
+	golangci-lint run ./...
+
 $(GENERATED):
 	./hack/update-codegen.sh
 

--- a/cmd/e2e/autoscale_test.go
+++ b/cmd/e2e/autoscale_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/cenk/backoff"
 	"github.com/stretchr/testify/require"
 	zv1 "github.com/zalando-incubator/es-operator/pkg/apis/zalando.org/v1"
-	"testing"
 )
 
 func TestEDSCPUAutoscaleUP(t *testing.T) {

--- a/cmd/e2e/basic_test.go
+++ b/cmd/e2e/basic_test.go
@@ -38,7 +38,7 @@ func (f *TestEDSSpecFactory) Scaling(scaling *zv1.ElasticsearchDataSetScaling) *
 func (f *TestEDSSpecFactory) Create() zv1.ElasticsearchDataSetSpec {
 	var result = zv1.ElasticsearchDataSetSpec{
 		Replicas: &f.replicas,
-		Scaling: f.scaling,
+		Scaling:  f.scaling,
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{

--- a/cmd/e2e/test_environment.go
+++ b/cmd/e2e/test_environment.go
@@ -12,7 +12,7 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 	appsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
-	"k8s.io/client-go/kubernetes/typed/core/v1"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )

--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -300,7 +300,7 @@ func updateEDS(name string, eds *zv1.ElasticsearchDataSet) error {
 }
 
 func deleteEDS(name string) error {
-	err := edsInterface().Delete(name, &metav1.DeleteOptions{ GracePeriodSeconds: pint64(10), })
+	err := edsInterface().Delete(name, &metav1.DeleteOptions{GracePeriodSeconds: pint64(10)})
 	return err
 }
 

--- a/operator/autoscaler.go
+++ b/operator/autoscaler.go
@@ -7,7 +7,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	zv1 "github.com/zalando-incubator/es-operator/pkg/apis/zalando.org/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // 1. check if we have enough data
@@ -272,14 +272,13 @@ func (as *AutoScaler) scaleUpOrDown(esIndices map[string]ESIndex, direction Scal
 				if index.Replicas >= scalingSpec.MaxIndexReplicas {
 					return noopScalingOperation(fmt.Sprintf("Not allowed to scale up due to maxIndexReplicas (%d) reached for index %s.",
 						scalingSpec.MaxIndexReplicas, index.Index))
-				} else {
-					newTotalShards += index.Primaries
-					newDesiredIndexReplicas = append(newDesiredIndexReplicas, ESIndex{
-						Index:     index.Index,
-						Primaries: index.Primaries,
-						Replicas:  index.Replicas + 1,
-					})
 				}
+				newTotalShards += index.Primaries
+				newDesiredIndexReplicas = append(newDesiredIndexReplicas, ESIndex{
+					Index:     index.Index,
+					Primaries: index.Primaries,
+					Replicas:  index.Replicas + 1,
+				})
 			}
 			if newTotalShards != currentTotalShards {
 				newDesiredNodeReplicas := as.ensureUpperBoundNodeReplicas(scalingSpec, int32(math.Ceil(float64(newTotalShards)/float64(currentShardToNodeRatio))))

--- a/operator/elasticsearch.go
+++ b/operator/elasticsearch.go
@@ -675,15 +675,14 @@ func edsReplicas(eds *zv1.ElasticsearchDataSet) int32 {
 			return 1
 		}
 		return *eds.Spec.Replicas
-	} else {
-		// initialize with minReplicas
-		minReplicas := eds.Spec.Scaling.MinReplicas
-		if eds.Spec.Replicas == nil {
-			return minReplicas
-		}
-		currentReplicas := *eds.Spec.Replicas
-		return int32(math.Max(float64(currentReplicas), float64(scaling.MinReplicas)))
 	}
+	// initialize with minReplicas
+	minReplicas := eds.Spec.Scaling.MinReplicas
+	if eds.Spec.Replicas == nil {
+		return minReplicas
+	}
+	currentReplicas := *eds.Spec.Replicas
+	return int32(math.Max(float64(currentReplicas), float64(scaling.MinReplicas)))
 }
 
 // collectResources collects all the ElasticsearchDataSet resources and there

--- a/operator/es_client.go
+++ b/operator/es_client.go
@@ -13,8 +13,7 @@ import (
 
 	"github.com/go-resty/resty"
 	log "github.com/sirupsen/logrus"
-
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // TODO make configurable as flags.

--- a/operator/es_client_test.go
+++ b/operator/es_client_test.go
@@ -1,12 +1,13 @@
 package operator
 
 import (
+	"net/url"
+	"testing"
+
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/api/core/v1"
-	"net/url"
-	"testing"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestDrain(t *testing.T) {

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 


### PR DESCRIPTION
## Description
Golangci-lint is a linter aggregator which enables a lot of good linters like errcheck, govet and golint.

## Types of Changes

- Travis will run golangci-lint after  running tests
- More visibility for PR's 
![image](https://user-images.githubusercontent.com/1936982/55871790-bb272f80-5b8b-11e9-848d-f0ea8a2cc83a.png)
