### PR TITLE
Add TypeMeta information after updating status

### DIFF
--- a/operator/elasticsearch.go
+++ b/operator/elasticsearch.go
@@ -515,6 +515,11 @@ func (r *EDSResource) UpdateStatus(sts *appsv1.StatefulSet) error {
 		if err != nil {
 			return err
 		}
+
+		// set TypeMeta manually because of this bug:
+		// https://github.com/kubernetes/client-go/issues/308
+		r.eds.APIVersion = "zalando.org/v1"
+		r.eds.Kind = "ElasticsearchDataSet"
 	}
 
 	return nil


### PR DESCRIPTION
This manually sets the correct `TypeMeta` information after updating `r.eds` when calling `UpdateStatus`. This is done because the `TypeMeta` is missing from the returned updated resource.

Should fix #43 

