### PR TITLE
Don't overwrite struct field on error

### DIFF
--- a/operator/elasticsearch.go
+++ b/operator/elasticsearch.go
@@ -510,16 +510,16 @@ func (r *EDSResource) UpdateStatus(sts *appsv1.StatefulSet) error {
 		r.eds.Status.Replicas != replicas {
 		r.eds.Status.Replicas = replicas
 		r.eds.Status.ObservedGeneration = &r.eds.Generation
-		var err error
-		r.eds, err = r.kube.ZalandoV1().ElasticsearchDataSets(r.eds.Namespace).UpdateStatus(r.eds)
+		eds, err := r.kube.ZalandoV1().ElasticsearchDataSets(r.eds.Namespace).UpdateStatus(r.eds)
 		if err != nil {
 			return err
 		}
 
 		// set TypeMeta manually because of this bug:
 		// https://github.com/kubernetes/client-go/issues/308
-		r.eds.APIVersion = "zalando.org/v1"
-		r.eds.Kind = "ElasticsearchDataSet"
+		eds.APIVersion = "zalando.org/v1"
+		eds.Kind = "ElasticsearchDataSet"
+		r.eds = eds
 	}
 
 	return nil


### PR DESCRIPTION
In case of error the `eds` struct field would be overwritten with an
'empty' value and used in the next iteration of the operation loop which
would result in the errors:

```
Failed to operate resource: failed to ensure resources: resource name may not be empty
```

Instead only update the `eds` struct field when the `UpdateStatus` call
is successful.

Fix #43