### PR TITLE
Avoid irritating scaling message

### DIFF
--- a/operator/autoscaler.go
+++ b/operator/autoscaler.go
@@ -2,7 +2,9 @@ package operator
 
 import (
 	"fmt"
+
 	"math"
+
 	"time"
 
 	log "github.com/sirupsen/logrus"

--- a/operator/elasticsearch.go
+++ b/operator/elasticsearch.go
@@ -292,7 +292,7 @@ func (r *EDSResource) UID() types.UID {
 }
 
 func (r *EDSResource) Replicas() int32 {
-	return r.Replicas()
+	return edsReplicas(r.eds)
 }
 
 func (r *EDSResource) PodTemplateSpec() *v1.PodTemplateSpec {
@@ -690,7 +690,12 @@ type ESResource struct {
 // Replicas returns the desired node replicas of an ElasticsearchDataSet
 // In case it was not specified, it will return '1'.
 func (es *ESResource) Replicas() int32 {
-	eds := es.ElasticsearchDataSet
+	return edsReplicas(es.ElasticsearchDataSet)
+}
+
+// edsReplicas returns the desired node replicas of an ElasticsearchDataSet
+// In case it was not specified, it will return '1'.
+func edsReplicas(eds *zv1.ElasticsearchDataSet) int32 {
 	scaling := eds.Spec.Scaling
 	if scaling == nil || !scaling.Enabled {
 		if eds.Spec.Replicas == nil {
@@ -795,7 +800,7 @@ func (o *ElasticsearchOperator) scaleEDS(eds *zv1.ElasticsearchDataSet, es *ESRe
 	name := eds.Name
 	namespace := eds.Namespace
 
-	currentReplicas := es.Replicas()
+	currentReplicas := edsReplicas(eds)
 	eds.Spec.Replicas = &currentReplicas
 	as := NewAutoScaler(es, o.metricsInterval, client)
 

--- a/operator/elasticsearch.go
+++ b/operator/elasticsearch.go
@@ -292,7 +292,7 @@ func (r *EDSResource) UID() types.UID {
 }
 
 func (r *EDSResource) Replicas() int32 {
-	return edsReplicas(r.eds)
+	return r.Replicas()
 }
 
 func (r *EDSResource) PodTemplateSpec() *v1.PodTemplateSpec {
@@ -690,12 +690,7 @@ type ESResource struct {
 // Replicas returns the desired node replicas of an ElasticsearchDataSet
 // In case it was not specified, it will return '1'.
 func (es *ESResource) Replicas() int32 {
-	return edsReplicas(es.ElasticsearchDataSet)
-}
-
-// edsReplicas returns the desired node replicas of an ElasticsearchDataSet
-// In case it was not specified, it will return '1'.
-func edsReplicas(eds *zv1.ElasticsearchDataSet) int32 {
+	eds := es.ElasticsearchDataSet
 	scaling := eds.Spec.Scaling
 	if scaling == nil || !scaling.Enabled {
 		if eds.Spec.Replicas == nil {
@@ -800,7 +795,7 @@ func (o *ElasticsearchOperator) scaleEDS(eds *zv1.ElasticsearchDataSet, es *ESRe
 	name := eds.Name
 	namespace := eds.Namespace
 
-	currentReplicas := edsReplicas(eds)
+	currentReplicas := es.Replicas()
 	eds.Spec.Replicas = &currentReplicas
 	as := NewAutoScaler(es, o.metricsInterval, client)
 


### PR DESCRIPTION
## Expected Behavior

Only log that es-operator is scaling, if there is an actual change in replicas

## Actual Behavior

es-operator keeps logging "Updating desired scaling for EDS .... New desired replicas: 20. Decreasing node replicas to 20.", although the current replicas are already 20 (=minReplicas)

> Fixes Issue #40

## Types of Changes

Ensure actual scalingDirection is properly differentiated from scalingHint. If there is no change in node count, the scalingDirection should always be NONE.
