### PR TITLE
Prioritize pods on unschedulable nodes

### DIFF
--- a/operator/operator.go
+++ b/operator/operator.go
@@ -506,12 +506,12 @@ func (o *Operator) getPodToUpdate(pods []v1.Pod, sts *appsv1.StatefulSet, sr Sta
 		return nil, nil
 	}
 
-	prioritizedNodes, cordonedNodes, err := o.getNodes()
+	prioritizedNodes, unschedulableNodes, err := o.getNodes()
 	if err != nil {
 		return nil, err
 	}
 
-	prioritizedPods, err := prioritizePodsForUpdate(pods, sts, sr, prioritizedNodes, cordonedNodes)
+	prioritizedPods, err := prioritizePodsForUpdate(pods, sts, sr, prioritizedNodes, unschedulableNodes)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is an optimization to prioritize pods on nodes which are marked
unschedulable higher than pods on schedulable nodes. Unschedulable nodes
indicate that the node is being drained, so it makes sense to move those
pods as soon as possible.