### PR TITLE
 #66 ES Operator doesn't scale-down to its boundary

### DIFF
--- a/operator/autoscaler.go
+++ b/operator/autoscaler.go
@@ -325,7 +325,7 @@ func (as *AutoScaler) scaleUpOrDown(esIndices map[string]ESIndex, scalingHint Sc
 		// increase shard-to-node ratio, and scale down by at least one
 		newDesiredNodeReplicas := as.ensureLowerBoundNodeReplicas(scalingSpec, calculateDecreasedNodes(currentDesiredNodeReplicas, currentTotalShards))
 		ratio := float64(newTotalShards) / float64(newDesiredNodeReplicas)
-		if ratio >= float64(scalingSpec.MaxShardsPerNode) {
+		if ratio > float64(scalingSpec.MaxShardsPerNode) {
 			return noopScalingOperation(fmt.Sprintf("Scaling would violate the shard-to-node maximum (%.2f/%d).", ratio, scalingSpec.MaxShardsPerNode))
 		}
 

--- a/operator/autoscaler_test.go
+++ b/operator/autoscaler_test.go
@@ -195,7 +195,6 @@ func TestScaleDownSnappingToNonFractionedShardToNodeRatio(t *testing.T) {
 	eds := edsTestFixture(14)
 	esNodes := make([]ESNode, 0)
 
-	// scale up by adding replicas
 	esIndices := map[string]ESIndex{
 		"ad1": {Replicas: 1, Primaries: 12, Index: "ad1"},
 	}
@@ -224,6 +223,29 @@ func TestScaleDown(t *testing.T) {
 	actual := as.calculateScalingOperation(esIndices, esNodes, scalingHint)
 	require.Equal(t, int32(3), *actual.NodeReplicas, actual.Description)
 	require.Equal(t, DOWN, actual.ScalingDirection, actual.Description)
+}
+
+func TestScaleDownToLowestBoundary(t *testing.T) {
+	eds := edsTestFixture(4)
+	eds.Spec.Scaling.MaxShardsPerNode = 40
+
+	esNodes := make([]ESNode, 0)
+
+	// scale down
+	esIndices := map[string]ESIndex{
+		"a": {Replicas: 1, Primaries: 12, Index: "a"},
+		"b": {Replicas: 1, Primaries: 12, Index: "b"},
+		"c": {Replicas: 1, Primaries: 12, Index: "c"},
+		"d": {Replicas: 1, Primaries: 12, Index: "d"},
+		"e": {Replicas: 1, Primaries: 12, Index: "e"},
+	}
+	scalingHint := DOWN
+
+	as := systemUnderTest(eds, nil, nil)
+
+	actual := as.calculateScalingOperation(esIndices, esNodes, scalingHint)
+	require.Equal(t, DOWN, actual.ScalingDirection, actual.Description)
+	require.Equal(t, int32(3), *actual.NodeReplicas, actual.Description)
 }
 
 func TestCannotScaleDownAnymore(t *testing.T) {


### PR DESCRIPTION
Closes #66 