### PR TITLE
Allow skipping draining of pods during update/scaledown

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ apiVersion: zalando.org/v1
 kind: ElasticsearchDataSet
 spec:
   replicas: 2
+  skipDraining: false
   scaling:
     enabled: true
     minReplicas: 1
@@ -69,6 +70,7 @@ spec:
 |----------|---------------|---------|
 | spec.replicas | Initial size of the StatefulSet. If auto-scaling is disabled, this is your desired cluster size. | Int |
 | spec.excludeSystemIndices | Enable or disable inclusion of system indices like '.kibana' when calculating shard-per-node ratio and scaling index replica counts. Those are usually managed by Elasticsearch internally. Default is false for backwards compatibility | Boolean |
+| spec.skipDraining | Allows the ES Operator to terminate an Elasticsearch node without re-allocating its data. This is useful for persistent disk setups, like EBS volumes. Beware that the ES Operator does not verify that you have more than one copy of your indices and therefore wouldn't protect you from potential data loss. (default=false) | Boolean |
 | spec.scaling.enabled | Enable or disable auto-scaling. May be necessary to enforce manual scaling. | Boolean |
 | spec.scaling.minReplicas | Minimum Pod replicas. Lower bound (inclusive) when scaling down.  | Int |
 | spec.scaling.maxReplicas | Maximum Pod replicas. Upper bound (inclusive) when scaling up.  | Int |

--- a/docs/zalando.org_elasticsearchdatasets.yaml
+++ b/docs/zalando.org_elasticsearchdatasets.yaml
@@ -119,6 +119,10 @@ spec:
                     minimum: 0
                     type: integer
                 type: object
+              skipDraining:
+                description: SkipDraining determines whether pods of the EDS should
+                  be drained before termination or not. Defaults to false
+                type: boolean
               template:
                 description: Template describes the pods that will be created.
                 properties:

--- a/docs/zalando.org_elasticsearchdatasets_v1beta1.yaml
+++ b/docs/zalando.org_elasticsearchdatasets_v1beta1.yaml
@@ -120,6 +120,10 @@ spec:
                   minimum: 0
                   type: integer
               type: object
+            skipDraining:
+              description: SkipDraining determines whether pods of the EDS should
+                be drained before termination or not. Defaults to false
+              type: boolean
             template:
               description: Template describes the pods that will be created.
               properties:

--- a/operator/elasticsearch.go
+++ b/operator/elasticsearch.go
@@ -510,6 +510,9 @@ func (r *EDSResource) ensureService(ctx context.Context) error {
 
 // Drain drains a pod for Elasticsearch data.
 func (r *EDSResource) Drain(ctx context.Context, pod *v1.Pod) error {
+	if r.eds.Spec.SkipDraining {
+		return nil
+	}
 	return r.esClient.Drain(ctx, pod)
 }
 

--- a/operator/es_client_test.go
+++ b/operator/es_client_test.go
@@ -3,7 +3,7 @@ package operator
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -69,7 +69,7 @@ func TestDrainWithTransientSettings(t *testing.T) {
 
 			if numCalls == 0 {
 				bodyReader, _ = request.GetBody()
-				intermediateClusterSettings, _ = ioutil.ReadAll(bodyReader)
+				intermediateClusterSettings, _ = io.ReadAll(bodyReader)
 			}
 
 			if esSettings.GetTransientExcludeIPs().ValueOrZero() != "" || esSettings.GetTransientRebalance().ValueOrZero() != "" {

--- a/operator/metrics_collector.go
+++ b/operator/metrics_collector.go
@@ -126,6 +126,6 @@ func (c *ElasticsearchMetricsCollector) storeMedian(ctx context.Context, i int32
 
 func calculateMedian(cpuMetrics []int32) int32 {
 	sort.Slice(cpuMetrics, func(i, j int) bool { return cpuMetrics[i] < cpuMetrics[j] })
-	// in case of odd number of samples we now get the lower one.
+	// in case of even number of samples we now get the lower one.
 	return cpuMetrics[(len(cpuMetrics)-1)/2]
 }

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -38,7 +38,8 @@ type ElasticsearchDataSetSpec struct {
 	ExcludeSystemIndices bool `json:"excludeSystemIndices"`
 
 	// SkipDraining determines whether pods of the EDS should be drained
-	// before termination or not.
+	// before termination or not. Defaults to false
+	// +optional
 	SkipDraining bool `json:"skipDraining"`
 
 	// // serviceName is the name of the service that governs this StatefulSet.

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -37,6 +37,10 @@ type ElasticsearchDataSetSpec struct {
 	// +optional
 	ExcludeSystemIndices bool `json:"excludeSystemIndices"`
 
+	// SkipDraining determines whether pods of the EDS should be drained
+	// before termination or not.
+	SkipDraining bool `json:"skipDraining"`
+
 	// // serviceName is the name of the service that governs this StatefulSet.
 	// // This service must exist before the StatefulSet, and is responsible for
 	// // the network identity of the set. Pods get DNS/hostnames that follow the


### PR DESCRIPTION
This is a simple proposal for how we could allow skipping of pod draining when during rolling update or scaledown of an `ElasticsearchDataSet`. It adds a field `spec.skipDraining` which when set to `true` will instruct the operator not to attempt to drain a pod before it is terminated. The field defaults to `false`.

We could also think about enabling this by default in case there are any `VolumeClaimTemplates` which is usually where you would want to not drain the pod but just terminate it and let the replacement pod remount the data from the PVC.

Fix #70