### PR TITLE
Use RBAC role for operator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 dist: xenial
 
 go:
-  - "1.12.x"
+  - "1.13.x"
 
 env:
 - GO111MODULE=on GOLANGCI_RELEASE="v1.16.0"

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -47,7 +47,7 @@ pipeline:
       metadata:
         name: e2e
       spec:
-        serviceAccountName: cdp
+        serviceAccountName: es-operator
         restartPolicy: Never
         containers:
           - name: e2e

--- a/deploy/e2e/apply/account_cdp.yaml
+++ b/deploy/e2e/apply/account_cdp.yaml
@@ -1,1 +1,0 @@
-../../../manifests/account_cdp.yaml

--- a/deploy/e2e/apply/rbac.yaml
+++ b/deploy/e2e/apply/rbac.yaml
@@ -1,0 +1,1 @@
+../../../manifests/rbac.yaml

--- a/docs/elasticsearch-cluster.yaml
+++ b/docs/elasticsearch-cluster.yaml
@@ -1,10 +1,4 @@
 apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: operator
-  namespace: es-operator-demo
----
-apiVersion: v1
 kind: ConfigMap
 metadata:
   name: es-config

--- a/docs/es-operator.yaml
+++ b/docs/es-operator.yaml
@@ -9,6 +9,12 @@ metadata:
   name: operator
   namespace: es-operator-demo
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: es-operator
+  namespace: es-operator-demo
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,7 +36,7 @@ spec:
         application: es-operator
         version: latest
     spec:
-      serviceAccountName: operator
+      serviceAccountName: es-operator
       containers:
       - name: es-operator
         image: registry.opensource.zalan.do/poirot/es-operator:latest

--- a/go.mod
+++ b/go.mod
@@ -49,3 +49,5 @@ require (
 )
 
 replace k8s.io/klog => github.com/mikkeloscar/knolog v0.0.0-20190326191552-80742771eb6b
+
+go 1.13

--- a/manifests/account_cdp.yaml
+++ b/manifests/account_cdp.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cdp

--- a/manifests/es-operator.yaml
+++ b/manifests/es-operator.yaml
@@ -18,7 +18,7 @@ spec:
         application: es-operator
         version: latest
     spec:
-      serviceAccountName: cdp
+      serviceAccountName: es-operator
       containers:
       - name: es-operator
         image: {{{IMAGE}}}

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -1,3 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: es-operator
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -14,6 +19,10 @@ rules:
   - get
   - list
   - watch
+  - update
+  - patch
+  # used by e2e test runner
+  - create
   - update
   - patch
 - apiGroups:
@@ -92,4 +101,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: es-operator
-  namespace: es-operator-demo
+  namespace: "{{{NAMESPACE}}}"


### PR DESCRIPTION
Integrate RBAC role for operator to get rid of magic `cdp` serviceAccount.