### PR TITLE
Use pod and node informers to reduce APIServer load

### DIFF
--- a/operator/elasticsearch.go
+++ b/operator/elasticsearch.go
@@ -23,6 +23,9 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeinformers "k8s.io/client-go/informers"
+	informersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	kube_record "k8s.io/client-go/tools/record"
 )
@@ -37,6 +40,8 @@ const (
 type ElasticsearchOperator struct {
 	logger                *log.Entry
 	kube                  *clientset.Clientset
+	podInformer           informersv1.PodInformer
+	nodeInformer          informersv1.NodeInformer
 	interval              time.Duration
 	autoscalerInterval    time.Duration
 	metricsInterval       time.Duration
@@ -74,6 +79,7 @@ func NewElasticsearchOperator(
 	clusterDNSZone string,
 	elasticsearchEndpoint *url.URL,
 ) *ElasticsearchOperator {
+
 	return &ElasticsearchOperator{
 		logger: log.WithFields(
 			log.Fields{
@@ -94,13 +100,58 @@ func NewElasticsearchOperator(
 	}
 }
 
+// setup informers for pods and nodes.
+func (o *ElasticsearchOperator) setupInformers(ctx context.Context) error {
+	informerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(o.kube, 0, kubeinformers.WithNamespace(o.namespace))
+	podInformer := informerFactory.Core().V1().Pods()
+	nodeInformer := informerFactory.Core().V1().Nodes()
+
+	informers := []cache.SharedIndexInformer{
+		podInformer.Informer(),
+		nodeInformer.Informer(),
+	}
+
+	for _, informer := range informers {
+		// Add default resource event handlers to properly initialize informer.
+		_, err := informer.AddEventHandler(
+			cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {},
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to add event handler: %v", err)
+		}
+	}
+
+	informerFactory.Start(ctx.Done())
+
+	for _, informer := range informers {
+		// wait for the local cache to be populated.
+		err := wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(_ context.Context) (bool, error) {
+			return informer.HasSynced() == true, nil
+		})
+		if err != nil {
+			return fmt.Errorf("failed to sync cache for informer: %v", err)
+		}
+	}
+
+	o.podInformer = podInformer
+	o.nodeInformer = nodeInformer
+	return nil
+}
+
 // Run runs the main loop of the operator.
 func (o *ElasticsearchOperator) Run(ctx context.Context) error {
+	err := o.setupInformers(ctx)
+	if err != nil {
+		return err
+	}
+
 	go o.collectMetrics(ctx)
 	go o.runAutoscaler(ctx)
 
 	// run EDS watcher
-	err := o.runWatch(ctx)
+	err = o.runWatch(ctx)
 	if err != nil {
 		return err
 	}
@@ -689,6 +740,8 @@ func (o *ElasticsearchOperator) operateEDS(eds *zv1.ElasticsearchDataSet, delete
 
 	operator := &Operator{
 		kube:                  o.kube,
+		podInformer:           o.podInformer,
+		nodeInformer:          o.nodeInformer,
 		priorityNodeSelectors: o.priorityNodeSelectors,
 		interval:              o.interval,
 		logger:                logger,
@@ -832,12 +885,13 @@ func (o *ElasticsearchOperator) collectResources(ctx context.Context) (map[types
 	}
 
 	// TODO: label filter
-	pods, err := o.kube.CoreV1().Pods(o.namespace).List(ctx, metav1.ListOptions{})
+	pods, err := o.podInformer.Lister().Pods(o.namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
 
-	for _, pod := range pods.Items {
+	for _, pod := range pods {
+		pod := *pod
 		for _, es := range resources {
 			es := es
 			// TODO: leaky abstraction

--- a/operator/operator_test.go
+++ b/operator/operator_test.go
@@ -166,7 +166,7 @@ func TestPrioritizePodsForUpdate(t *testing.T) {
 		"node3": {},
 	}
 
-	pods := []v1.Pod{updatingPod}
+	pods := []*v1.Pod{&updatingPod}
 
 	sortedPods, err := prioritizePodsForUpdate(pods, sts, sr, priorityNodes, unschedulableNodes)
 	assert.NoError(t, err)
@@ -174,28 +174,28 @@ func TestPrioritizePodsForUpdate(t *testing.T) {
 	assert.Equal(t, updatingPod, sortedPods[0])
 
 	// updating pod should be prioritized over stsPod
-	pods = []v1.Pod{stsPod, updatingPod}
+	pods = []*v1.Pod{&stsPod, &updatingPod}
 	sortedPods, err = prioritizePodsForUpdate(pods, sts, sr, priorityNodes, unschedulableNodes)
 	assert.NoError(t, err)
 	assert.Len(t, sortedPods, 2)
 	assert.Equal(t, updatingPod, sortedPods[0])
 
 	// stsPods should be sorted by ordinal number
-	pods = []v1.Pod{stsPod, stsPod0}
+	pods = []*v1.Pod{&stsPod, &stsPod0}
 	sortedPods, err = prioritizePodsForUpdate(pods, sts, sr, priorityNodes, unschedulableNodes)
 	assert.NoError(t, err)
 	assert.Len(t, sortedPods, 2)
 	assert.Equal(t, stsPod0, sortedPods[0])
 
 	// pods on unschedulable nodes should get higher priority
-	pods = []v1.Pod{stsPod, stsPod2}
+	pods = []*v1.Pod{&stsPod, &stsPod2}
 	sortedPods, err = prioritizePodsForUpdate(pods, sts, sr, priorityNodes, unschedulableNodes)
 	assert.NoError(t, err)
 	assert.Len(t, sortedPods, 2)
 	assert.Equal(t, stsPod2, sortedPods[0])
 
 	// don't prioritize pods not on a node.
-	pods = []v1.Pod{podNoNode}
+	pods = []*v1.Pod{&podNoNode}
 	sortedPods, err = prioritizePodsForUpdate(pods, sts, sr, priorityNodes, unschedulableNodes)
 	assert.NoError(t, err)
 	assert.Len(t, sortedPods, 0)
@@ -216,16 +216,16 @@ func TestPrioritizePodsForUpdate(t *testing.T) {
 		},
 	}
 
-	pods = []v1.Pod{podUpToDate}
+	pods = []*v1.Pod{&podUpToDate}
 	sortedPods, err = prioritizePodsForUpdate(pods, sts, sr, priorityNodes, unschedulableNodes)
 	assert.NoError(t, err)
 	assert.Len(t, sortedPods, 0)
 }
 
 func TestSortStatefulSetPods(t *testing.T) {
-	pods := make([]v1.Pod, 0, 13)
+	pods := make([]*v1.Pod, 0, 13)
 	for _, num := range []int{12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0} {
-		pods = append(pods, v1.Pod{
+		pods = append(pods, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:         fmt.Sprintf("sts-%d", num),
 				GenerateName: "sts-",


### PR DESCRIPTION
This introduces the use of informers for listing pods and nodes. It's inspired by what is done in external-dns: https://github.com/kubernetes-sigs/external-dns/blob/805555872ee7e27ab15802a86e313120432117fa/source/ingress.go#L78

The main idea of informers are that they use an internal cache which is maintained via a watch. Whenever the operator will do a list pods or list nodes it will read from the internal cache instead of making an API call to the APIServer thus reducing the load which is usually caused by listing pods in big clusters.

This needs a bit of testing before it can be considered. I had to change a lot of `[]v1.Pod` to `[]*v1.Pod` because of the informer semantics, but I don't fully understand the API yet so I won't to make sure we are still using the values in a safe way.
Additionally we need to understand how this watch behaves when there are connection issues to the APIServer.