### PR TITLE
Drop elasticsearchmetricsets/status permissions

### DIFF
--- a/docs/cluster-roles.yaml
+++ b/docs/cluster-roles.yaml
@@ -9,7 +9,6 @@ rules:
   - elasticsearchdatasets
   - elasticsearchdatasets/status
   - elasticsearchmetricsets
-  - elasticsearchmetricsets/status
   verbs:
   - get
   - list

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -14,7 +14,6 @@ rules:
   - elasticsearchdatasets
   - elasticsearchdatasets/status
   - elasticsearchmetricsets
-  - elasticsearchmetricsets/status
   verbs:
   - get
   - list


### PR DESCRIPTION
`elasticsearchmetricsets` doesn't have a `status` defined, so we should not need access to it via RBAC.