### PR TITLE
Create Dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: monthly
+    time: "07:00"
+  open-pull-requests-limit: 10
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: monthly
+    time: "07:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
:wave: Dependabot is moving natively into GitHub! This pull request migrates your configuration from Dependabot.com to a config file, using the [new syntax](https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates). When you merge this pull request, we'll swap out `dependabot-preview` (me) for a new `dependabot` app, and you'll be all set!

With this change, you'll now use the [Dependabot page in GitHub](https://github.com/zalando-incubator/kube-metrics-adapter/network/updates), rather than the [Dependabot dashboard](https://app.dependabot.com/), to monitor your version updates. Dependabot is now configured exclusively using config files.



The new version does not yet support private git dependencies. If you use these we recommend recommend leaving Dependabot Preview active.








If you've got any questions or feedback for us, please let us know by creating an issue in the [dependabot/dependabot-core](https://github.com/dependabot/dependabot-core/issues) repository.

[Learn more about the relaunch of Dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/)

Please note that regular `@dependabot` commands do not work on this pull request.

:robot::yellow_heart:
