### PR TITLE
wait for stable statefulset before scale replica

### DIFF
--- a/operator/operator.go
+++ b/operator/operator.go
@@ -313,6 +313,10 @@ func (o *Operator) operatePods(ctx context.Context, sts *appsv1.StatefulSet, sr 
 			return fmt.Errorf("failed to rescale StatefulSet: %v", err)
 		}
 
+		err = waitForStableStatefulSet(ctx, o.kube, sts, stabilizationTimeout)
+		if err != nil {
+			return fmt.Errorf("StatefulSet %s/%s is not stable: %v", sts.Namespace, sts.Name, err)
+		}
 		return sr.OnStableReplicasHook(ctx)
 	}
 


### PR DESCRIPTION
# One-line summary

Issue : #121 

## Description
The goal off this PR is to ensure statefulset is ready before scale up. I am testing on a cluster right now it seems to correctly fix the reported issues. However I am not sure it is the best way.

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)

## Tasks
  - [x] Ensure statefulset is stable before operate ES
  - [ ] test ?

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG
