### PR TITLE
Run e2e with unprivileged pods

### DIFF
--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -25,28 +25,6 @@ const (
 var (
 	edsPodSpec = func(nodeGroup, version, configMap string) v1.PodSpec {
 		return v1.PodSpec{
-			ServiceAccountName: "operator",
-			InitContainers: []v1.Container{
-				{
-					Name:    "init-sysctl",
-					Image:   "busybox:1.30",
-					Command: []string{"sysctl", "-w", "vm.max_map_count=262144"},
-					Resources: v1.ResourceRequirements{
-						Limits: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("50Mi"),
-							v1.ResourceCPU:    resource.MustParse("5m"),
-						},
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("50Mi"),
-							v1.ResourceCPU:    resource.MustParse("5m"),
-						},
-					},
-					SecurityContext: &v1.SecurityContext{
-						Privileged: pbool(true),
-						RunAsUser:  pint64(0),
-					},
-				},
-			},
 			Containers: []v1.Container{
 				{
 					Name: "elasticsearch",

--- a/deploy/e2e/apply/es6-master.yaml
+++ b/deploy/e2e/apply/es6-master.yaml
@@ -15,26 +15,8 @@ spec:
         application: es6
         role: master
     spec:
-      serviceAccountName: operator
       securityContext:
         fsGroup: 1000
-      initContainers:
-      - name: init-sysctl
-        image: busybox:1.30
-        command:
-        - sysctl
-        - -w
-        - vm.max_map_count=262144
-        resources:
-          requests:
-            memory: 50Mi
-            cpu: 50m
-          limits:
-            memory: 50Mi
-            cpu: 50m
-        securityContext:
-          privileged: true
-          runAsUser: 0
       containers:
       - name: elasticsearch
         resources:

--- a/deploy/e2e/apply/es7-master.yaml
+++ b/deploy/e2e/apply/es7-master.yaml
@@ -15,26 +15,8 @@ spec:
         application: es7
         role: master
     spec:
-      serviceAccountName: operator
       securityContext:
         fsGroup: 1000
-      initContainers:
-      - name: init-sysctl
-        image: busybox:1.30
-        command:
-        - sysctl
-        - -w
-        - vm.max_map_count=262144
-        resources:
-          requests:
-            memory: 50Mi
-            cpu: 50m
-          limits:
-            memory: 50Mi
-            cpu: 50m
-        securityContext:
-          privileged: true
-          runAsUser: 0
       containers:
       - name: elasticsearch
         resources:

--- a/deploy/e2e/apply/operator_service_account.yaml
+++ b/deploy/e2e/apply/operator_service_account.yaml
@@ -1,1 +1,0 @@
-../../../manifests/operator_service_account.yaml


### PR DESCRIPTION
We no longer have the *magic* `operator` service account in the cluster used for e2e. Drop the privileged part which is not needed in our clusters anyway.

Fixes e2e which are otherwise broken!