### PR TITLE
Use compliant Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM registry.opensource.zalan.do/stups/alpine:latest
-MAINTAINER Team Poirot @ Zalando SE <team-poirot@zalando.de>
+FROM registry.opensource.zalan.do/library/alpine-3.12:latest
+MAINTAINER Team Lens @ Zalando SE <team-lens@zalando.de>
 
 # add binary
 ADD build/linux/es-operator /

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,5 +1,5 @@
-FROM registry.opensource.zalan.do/stups/alpine:latest
-MAINTAINER Team Poirot @ Zalando SE <team-poirot@zalando.de>
+FROM registry.opensource.zalan.do/library/alpine-3.12:latest
+MAINTAINER Team Lens @ Zalando SE <team-lens@zalando.de>
 
 # add binary
 ADD build/linux/e2e /


### PR DESCRIPTION
Uses the new alpine Docker base image to become compliant with the company's docker build policy.
