### PR TITLE
feat: Update logic for ShardToNodeRatio and MinIndexReplicas

### DIFF
--- a/operator/autoscaler.go
+++ b/operator/autoscaler.go
@@ -225,20 +225,16 @@ func (as *AutoScaler) getMaxDiskUsage(managedNodes []ESNode) float64 {
 	return maxDisk
 }
 
-func (as *AutoScaler) ensureLowerBoundNodeReplicas(scalingSpec *zv1.ElasticsearchDataSetScaling, newDesiredNodeReplicas int32) int32 {
-	if scalingSpec.MinReplicas > 0 {
-		return int32(math.Max(float64(newDesiredNodeReplicas), float64(scalingSpec.MinReplicas)))
-	}
-	return newDesiredNodeReplicas
-}
-
-func (as *AutoScaler) ensureUpperBoundNodeReplicas(scalingSpec *zv1.ElasticsearchDataSetScaling, newDesiredNodeReplicas int32) int32 {
+func (as *AutoScaler) ensureBoundsNodeReplicas(scalingSpec *zv1.ElasticsearchDataSetScaling, newDesiredNodeReplicas int32) int32 {
 	if scalingSpec.MaxReplicas > 0 {
-		upperBound := int32(math.Min(float64(newDesiredNodeReplicas), float64(scalingSpec.MaxReplicas)))
-		if upperBound < newDesiredNodeReplicas {
+		newDesiredNodeReplicas = int32(math.Min(float64(newDesiredNodeReplicas), float64(scalingSpec.MaxReplicas)))
+		if int32(scalingSpec.MaxReplicas) < newDesiredNodeReplicas {
 			as.logger.Warnf("Requested to scale up to %d, which is beyond the defined maxReplicas of %d.", newDesiredNodeReplicas, scalingSpec.MaxReplicas)
+			return newDesiredNodeReplicas
 		}
-		return upperBound
+	}
+	if scalingSpec.MinReplicas > 0 {
+		newDesiredNodeReplicas = int32(math.Max(float64(newDesiredNodeReplicas), float64(scalingSpec.MinReplicas)))
 	}
 	return newDesiredNodeReplicas
 }
@@ -262,24 +258,24 @@ func (as *AutoScaler) scaleUpOrDown(esIndices map[string]ESIndex, scalingHint Sc
 		}
 	}
 
+	currentShardToNodeRatio := float64(currentTotalShards) / float64(currentDesiredNodeReplicas)
+
+	// independent of the scaling direction: in case the scaling setting MaxShardsPerNode has changed, we might need to scale up.
+	if currentShardToNodeRatio > float64(scalingSpec.MaxShardsPerNode) {
+		newDesiredNodeReplicas := as.ensureBoundsNodeReplicas(scalingSpec, int32(math.Ceil(float64(currentTotalShards)/float64(scalingSpec.MaxShardsPerNode))))
+		return &ScalingOperation{
+			ScalingDirection: as.calculateScalingDirection(currentDesiredNodeReplicas, newDesiredNodeReplicas),
+			NodeReplicas:     &newDesiredNodeReplicas,
+			Description:      fmt.Sprintf("Current shard-to-node ratio (%.2f) exceeding the desired limit of (%d).", currentShardToNodeRatio, scalingSpec.MaxShardsPerNode),
+		}
+	}
+
 	// independent of the scaling direction: in case there are indices with < MinIndexReplicas, we try to scale these indices.
 	if len(newDesiredIndexReplicas) > 0 {
 		return &ScalingOperation{
 			ScalingDirection: UP,
 			IndexReplicas:    newDesiredIndexReplicas,
 			Description:      "Scale indices replicas to fit MinIndexReplicas requirement",
-		}
-	}
-
-	currentShardToNodeRatio := float64(currentTotalShards) / float64(currentDesiredNodeReplicas)
-
-	// independent of the scaling direction: in case the scaling setting MaxShardsPerNode has changed, we might need to scale up.
-	if currentShardToNodeRatio > float64(scalingSpec.MaxShardsPerNode) {
-		newDesiredNodeReplicas := as.ensureUpperBoundNodeReplicas(scalingSpec, int32(math.Ceil(float64(currentTotalShards)/float64(scalingSpec.MaxShardsPerNode))))
-		return &ScalingOperation{
-			ScalingDirection: as.calculateScalingDirection(currentDesiredNodeReplicas, newDesiredNodeReplicas),
-			NodeReplicas:     &newDesiredNodeReplicas,
-			Description:      fmt.Sprintf("Current shard-to-node ratio (%.2f) exceeding the desired limit of (%d).", currentShardToNodeRatio, scalingSpec.MaxShardsPerNode),
 		}
 	}
 
@@ -302,15 +298,20 @@ func (as *AutoScaler) scaleUpOrDown(esIndices map[string]ESIndex, scalingHint Sc
 			if newTotalShards != currentTotalShards {
 				newDesiredNodeReplicas := currentDesiredNodeReplicas
 
-				currentShardToNodeRatio = float64(newTotalShards) / float64(currentDesiredNodeReplicas)
+				scalingMsg := "Increasing index replicas."
+
+				targetShardToNodeRatio := float64(newTotalShards) / float64(currentDesiredNodeReplicas)
 				// Evaluate new number of nodes only if we above MinShardsPerNode parameter
-				if currentShardToNodeRatio >= float64(scalingSpec.MinShardsPerNode) {
-					newDesiredNodeReplicas = as.ensureUpperBoundNodeReplicas(scalingSpec,
+				if targetShardToNodeRatio >= float64(scalingSpec.MinShardsPerNode) {
+					newDesiredNodeReplicas = as.ensureBoundsNodeReplicas(scalingSpec,
 						calculateNodesWithSameShardToNodeRatio(currentDesiredNodeReplicas, currentTotalShards, newTotalShards))
+					if newDesiredNodeReplicas != currentDesiredNodeReplicas {
+						scalingMsg = fmt.Sprintf("Keeping shard-to-node ratio (%.2f), and increasing index replicas.", targetShardToNodeRatio)
+					}
 				}
 
 				return &ScalingOperation{
-					Description:      fmt.Sprintf("Keeping shard-to-node ratio (%.2f), and increasing index replicas.", currentShardToNodeRatio),
+					Description:      scalingMsg,
 					NodeReplicas:     &newDesiredNodeReplicas,
 					IndexReplicas:    newDesiredIndexReplicas,
 					// we don't use "as.calculateScalingDirection" because the func "calculateNodesWithSameShardToNodeRatio" can produce the same number of nodes
@@ -321,7 +322,7 @@ func (as *AutoScaler) scaleUpOrDown(esIndices map[string]ESIndex, scalingHint Sc
 		}
 
 		// round down to the next non-fractioned shard-to-node ratio
-		newDesiredNodeReplicas := as.ensureUpperBoundNodeReplicas(scalingSpec, calculateIncreasedNodes(currentDesiredNodeReplicas, currentTotalShards))
+		newDesiredNodeReplicas := as.ensureBoundsNodeReplicas(scalingSpec, calculateIncreasedNodes(currentDesiredNodeReplicas, currentTotalShards))
 
 		return &ScalingOperation{
 			ScalingDirection: as.calculateScalingDirection(currentDesiredNodeReplicas, newDesiredNodeReplicas),
@@ -341,7 +342,7 @@ func (as *AutoScaler) scaleUpOrDown(esIndices map[string]ESIndex, scalingHint Sc
 			}
 		}
 		if newTotalShards != currentTotalShards {
-			newDesiredNodeReplicas := as.ensureLowerBoundNodeReplicas(scalingSpec, calculateNodesWithSameShardToNodeRatio(currentDesiredNodeReplicas, currentTotalShards, newTotalShards))
+			newDesiredNodeReplicas := as.ensureBoundsNodeReplicas(scalingSpec, calculateNodesWithSameShardToNodeRatio(currentDesiredNodeReplicas, currentTotalShards, newTotalShards))
 			return &ScalingOperation{
 				ScalingDirection: as.calculateScalingDirection(currentDesiredNodeReplicas, newDesiredNodeReplicas),
 				NodeReplicas:     &newDesiredNodeReplicas,
@@ -350,7 +351,7 @@ func (as *AutoScaler) scaleUpOrDown(esIndices map[string]ESIndex, scalingHint Sc
 			}
 		}
 		// increase shard-to-node ratio, and scale down by at least one
-		newDesiredNodeReplicas := as.ensureLowerBoundNodeReplicas(scalingSpec, calculateDecreasedNodes(currentDesiredNodeReplicas, currentTotalShards))
+		newDesiredNodeReplicas := as.ensureBoundsNodeReplicas(scalingSpec, calculateDecreasedNodes(currentDesiredNodeReplicas, currentTotalShards))
 		ratio := float64(newTotalShards) / float64(newDesiredNodeReplicas)
 		if ratio > float64(scalingSpec.MaxShardsPerNode) {
 			return noopScalingOperation(fmt.Sprintf("Scaling would violate the shard-to-node maximum (%.2f/%d).", ratio, scalingSpec.MaxShardsPerNode))

--- a/operator/autoscaler.go
+++ b/operator/autoscaler.go
@@ -313,7 +313,9 @@ func (as *AutoScaler) scaleUpOrDown(esIndices map[string]ESIndex, scalingHint Sc
 					Description:      fmt.Sprintf("Keeping shard-to-node ratio (%.2f), and increasing index replicas.", currentShardToNodeRatio),
 					NodeReplicas:     &newDesiredNodeReplicas,
 					IndexReplicas:    newDesiredIndexReplicas,
-					ScalingDirection: as.calculateScalingDirection(currentDesiredNodeReplicas, newDesiredNodeReplicas),
+					// we don't use "as.calculateScalingDirection" because the func "calculateNodesWithSameShardToNodeRatio" can produce the same number of nodes
+					// but we still need to scale up shards
+					ScalingDirection: UP,
 				}
 			}
 		}

--- a/operator/autoscaler_test.go
+++ b/operator/autoscaler_test.go
@@ -342,7 +342,7 @@ func TestScaleUpCausedByShardToNodeRatioExceeded(t *testing.T) {
 	require.Equal(t, UP, actual.ScalingDirection, actual.Description)
 }
 
-func TestScaleDownCausedByShardToNodeRatioLessThanOne(t *testing.T) {
+func TestScaleUpCausedByShardToNodeRatioLessThanOne(t *testing.T) {
 	eds := edsTestFixture(11)
 	esNodes := make([]ESNode, 0)
 

--- a/operator/autoscaler_test.go
+++ b/operator/autoscaler_test.go
@@ -564,6 +564,16 @@ func edsTestFixture(initialReplicas int) *zv1.ElasticsearchDataSet {
 	}
 }
 
+func TestCalculateNodeBoundaries(t *testing.T) {
+	eds := edsTestFixture(3)
+	eds.Spec.Scaling.MinReplicas = 2
+	eds.Spec.Scaling.MaxReplicas = 5
+	as := systemUnderTest(eds, nil, nil)
+	require.Equal(t, 2, int(as.ensureBoundsNodeReplicas(1)))
+	require.Equal(t, 3, int(as.ensureBoundsNodeReplicas(3)))
+	require.Equal(t, 5, int(as.ensureBoundsNodeReplicas(6)))
+}
+
 func TestCalculateIncreasedNodes(t *testing.T) {
 	require.Equal(t, 64, int(calculateIncreasedNodes(32, 64)))
 	require.Equal(t, 64, int(calculateIncreasedNodes(64, 64)))

--- a/operator/autoscaler_test.go
+++ b/operator/autoscaler_test.go
@@ -272,9 +272,10 @@ func TestIncreaseShardToNodeRatioMore(t *testing.T) {
 
 	// scale-down even if this means increasing shard-to-node ratio of more than +1
 	esIndices := map[string]ESIndex{
-		"ad1": {Replicas: 1, Primaries: 21, Index: "ad1"},
-		"ad2": {Replicas: 1, Primaries: 2, Index: "ad2"},
+		"ad1": {Replicas: 0, Primaries: 42, Index: "ad1"},
+		"ad2": {Replicas: 0, Primaries: 4, Index: "ad2"},
 	}
+	eds.Spec.Scaling.MinIndexReplicas = 0
 	eds.Spec.Scaling.MaxShardsPerNode = 23
 	scalingHint := DOWN
 
@@ -342,22 +343,25 @@ func TestScaleUpCausedByShardToNodeRatioExceeded(t *testing.T) {
 }
 
 func TestScaleDownCausedByShardToNodeRatioLessThanOne(t *testing.T) {
-	eds := edsTestFixture(12)
+	eds := edsTestFixture(11)
 	esNodes := make([]ESNode, 0)
 
-	// require to scale-up because we exceeded shard-to-node ratio limits.
-	eds.Spec.Scaling.MaxShardsPerNode = 6
+	// require to scale-up index replicas because we are below one shard per node.
+	eds.Spec.Scaling.MinReplicas = 11
 	eds.Spec.Scaling.MaxReplicas = 999
+
 	esIndices := map[string]ESIndex{
-		"ad1": {Replicas: 1, Primaries: 3, Index: "ad1"},
+		"ad1": {Replicas: 1, Primaries: 5, Index: "ad1"},
 	}
+	// calculated ShardToNode ratio is 10/11 ~ 0.9
+	eds.Spec.Scaling.MinShardsPerNode = 1
 	// scaling independent of desired scaling direction
 	scalingHint := UP
 
 	as := systemUnderTest(eds, nil, nil)
 
 	actual := as.calculateScalingOperation(esIndices, esNodes, scalingHint)
-	require.Equal(t, int32(12), *actual.NodeReplicas, actual.Description)
+	require.Equal(t, int32(11), *actual.NodeReplicas, actual.Description)
 	require.Equal(t, 1, len(actual.IndexReplicas), actual.Description)
 	require.Equal(t, UP, actual.ScalingDirection, actual.Description)
 }
@@ -366,12 +370,18 @@ func TestAtMaxShardsPerNode(t *testing.T) {
 	eds := edsTestFixture(4)
 	esNodes := make([]ESNode, 0)
 
-	// don't scale down if that would violate the maxShardsPerNode
-	eds.Spec.Scaling.MaxShardsPerNode = 12
 	esIndices := map[string]ESIndex{
 		"ad1": {Replicas: 1, Primaries: 18, Index: "ad1"},
 		"ad2": {Replicas: 1, Primaries: 5, Index: "ad2"},
 	}
+	// don't scale down if that would violate the maxShardsPerNode
+	// calculations:
+	//   ad1 shards = primaries shards + replicas shards = 18 + 1*18 = 36
+	//   ad2 shards = 5 * 1*5 = 10
+	//   total shards = 46
+	//   per node = 46/4 = 11.5
+	eds.Spec.Scaling.MaxShardsPerNode = 12
+
 	scalingHint := DOWN
 
 	as := systemUnderTest(eds, nil, nil)
@@ -390,7 +400,9 @@ func TestScaleMinIndexReplicas(t *testing.T) {
 	eds.Spec.Scaling.MinIndexReplicas = 2
 	esIndices := map[string]ESIndex{
 		"ad1": {Replicas: 0, Primaries: 1, Index: "ad1"},
-		"ad2": {Replicas: 0, Primaries: 1, Index: "ad2"},
+		"ad2": {Replicas: 1, Primaries: 1, Index: "ad2"},
+		"ad3": {Replicas: 2, Primaries: 1, Index: "ad3"},
+		"ad4": {Replicas: 3, Primaries: 1, Index: "ad4"},
 	}
 	scalingHint := DOWN
 
@@ -398,6 +410,8 @@ func TestScaleMinIndexReplicas(t *testing.T) {
 
 	actual := as.calculateScalingOperation(esIndices, esNodes, scalingHint)
 	require.Equal(t, 2, len(actual.IndexReplicas), actual.Description)
+	require.Contains(t, actual.IndexReplicas, ESIndex{Index: "ad1", Primaries: 1, Replicas: 2})
+	require.Contains(t, actual.IndexReplicas, ESIndex{Index: "ad2", Primaries: 1, Replicas: 2})
 	require.Equal(t, UP, actual.ScalingDirection, actual.Description)
 }
 
@@ -563,6 +577,8 @@ func TestCalculateDecreaseNodes(t *testing.T) {
 }
 
 func TestCalculateNodesWithSameShardToNodeRatio(t *testing.T) {
+	require.Equal(t, 16, int(calculateNodesWithSameShardToNodeRatio(16, 4, 4)))
+	require.Equal(t, 16, int(calculateNodesWithSameShardToNodeRatio(16, 4, 6)))
 	require.Equal(t, 12, int(calculateNodesWithSameShardToNodeRatio(16, 32, 24)))
 	require.Equal(t, 17, int(calculateNodesWithSameShardToNodeRatio(17, 32, 32)))
 }


### PR DESCRIPTION
## one line summary
> Issue : #141 

## Description
With this PR I try to fix a bug with setting minIndexReplicas on config change and update the logic for a ShardToNodeRatio param. 
Fix a function calculateNodesWithSameShardToNodeRatio, before if we have shards < nodes, the function conducts division to the number what is <1 (0 < n < 1), as a result function increases replicas.  
About an evaluation of number of nodes on checking MinShardsPerNode: looks like it makes sense to do it only in case of the new number of shards is more than MinShardsPerNode. 

## Types of Changes
Fix bug #141
Minor changes for ShardToNodeRatio param logic

## Review
_List of tasks the reviewer must do to review the PR_
- [x] Tests


## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
