### PR TITLE
Consistently use alpine-3.13

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,5 +1,5 @@
-FROM registry.opensource.zalan.do/library/alpine-3.12:latest
-MAINTAINER Team Lens @ Zalando SE <team-lens@zalando.de>
+FROM registry.opensource.zalan.do/library/alpine-3.13:latest
+LABEL maintainer="Team Lens @ Zalando SE <team-lens@zalando.de>"
 
 # add binary
 ADD build/linux/e2e /


### PR DESCRIPTION
Upgrade the Dockerfile used in the e2e-tests to use alpine-3.13
