### PR TITLE
feat(esClientDrain): enhance Drain ES Client function

### DIFF
--- a/operator/elasticsearch.go
+++ b/operator/elasticsearch.go
@@ -48,7 +48,7 @@ type ElasticsearchOperator struct {
 	operating             map[types.UID]operatingEntry
 	sync.Mutex
 	recorder            kube_record.EventRecorder
-	esClientRestyConfig *RestyConfig
+	esClientRetryConfig *RetryConfig
 }
 
 type operatingEntry struct {
@@ -88,7 +88,7 @@ func NewElasticsearchOperator(
 		elasticsearchEndpoint: elasticsearchEndpoint,
 		operating:             make(map[types.UID]operatingEntry),
 		recorder:              createEventRecorder(client),
-		esClientRestyConfig: &RestyConfig{
+		esClientRetryConfig: &RetryConfig{
 			ClientRetryCount:       esClientRetryCount,
 			ClientRetryWaitTime:    esClientRetryWaitTime,
 			ClientRetryMaxWaitTime: esClientRetryMaxWaitTime,
@@ -506,7 +506,7 @@ func (r *EDSResource) ensureService(ctx context.Context) error {
 }
 
 // Drain drains a pod for Elasticsearch data.
-func (r *EDSResource) Drain(ctx context.Context, pod *v1.Pod, config *RestyConfig) error {
+func (r *EDSResource) Drain(ctx context.Context, pod *v1.Pod, config *RetryConfig) error {
 	return r.esClient.Drain(ctx, pod, config)
 }
 
@@ -650,7 +650,7 @@ func (o *ElasticsearchOperator) operateEDS(eds *zv1.ElasticsearchDataSet, delete
 		interval:              o.interval,
 		logger:                logger,
 		recorder:              o.recorder,
-		esClientRestyConfig:   o.esClientRestyConfig,
+		esClientRetryConfig:   o.esClientRetryConfig,
 	}
 
 	rs := &EDSResource{

--- a/operator/elasticsearch_test.go
+++ b/operator/elasticsearch_test.go
@@ -15,6 +15,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const (
+	defaultRetryCount       = 999
+	defaultRetryWaitTime    = 10 * time.Second
+	defaultRetryMaxWaitTime = 30 * time.Second
+)
+
 func TestHasOwnership(t *testing.T) {
 	eds := &zv1.ElasticsearchDataSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -43,7 +49,8 @@ func TestGetElasticsearchEndpoint(t *testing.T) {
 	faker := &clientset.Clientset{
 		Interface: fake.NewSimpleClientset(),
 	}
-	esOperator := NewElasticsearchOperator(faker, nil, 1*time.Second, 1*time.Second, "", "", "cluster.local.", nil)
+	esOperator := NewElasticsearchOperator(faker, nil, 1*time.Second, 1*time.Second, "", "", "cluster.local.", nil,
+		defaultRetryCount, defaultRetryWaitTime, defaultRetryMaxWaitTime)
 
 	eds := &zv1.ElasticsearchDataSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -59,7 +66,8 @@ func TestGetElasticsearchEndpoint(t *testing.T) {
 	customEndpoint, err := url.Parse(customURL)
 	assert.NoError(t, err)
 
-	esOperator = NewElasticsearchOperator(faker, nil, 1*time.Second, 1*time.Second, "", "", ".cluster.local.", customEndpoint)
+	esOperator = NewElasticsearchOperator(faker, nil, 1*time.Second, 1*time.Second, "", "", ".cluster.local.", customEndpoint,
+		defaultRetryCount, defaultRetryWaitTime, defaultRetryMaxWaitTime)
 	url = esOperator.getElasticsearchEndpoint(eds)
 	assert.Equal(t, customURL, url.String())
 }

--- a/operator/es_client.go
+++ b/operator/es_client.go
@@ -324,6 +324,10 @@ func (c *ESClient) waitForEmptyEsNode(ctx context.Context, pod *v1.Pod, config *
 			// It is expected to return (bool, error) pair. Resty will retry
 			// in case condition returns true or non nil error.
 			func(r *resty.Response) (bool, error) {
+				if !r.IsSuccess() {
+					return true, nil
+				}
+
 				var shards []ESShard
 				err := json.Unmarshal(r.Body(), &shards)
 				if err != nil {
@@ -351,6 +355,10 @@ func (c *ESClient) waitForEmptyEsNode(ctx context.Context, pod *v1.Pod, config *
 
 	if err != nil {
 		return err
+	}
+
+	if !resp.IsSuccess() {
+		return fmt.Errorf("HTTP endpoint responded with not expected status code %d", resp.StatusCode())
 	}
 
 	// make sure the IP is still excluded, this could have been updated in the meantime.

--- a/operator/es_client_test.go
+++ b/operator/es_client_test.go
@@ -48,8 +48,8 @@ func TestDrain(t *testing.T) {
 
 	info := httpmock.GetCallCountInfo()
 	require.EqualValues(t, 1, info["GET http://elasticsearch:9200/_cluster/health"])
-	require.EqualValues(t, 3, info["PUT http://elasticsearch:9200/_cluster/settings"])
-	require.EqualValues(t, 2, info["GET http://elasticsearch:9200/_cluster/settings"])
+	require.EqualValues(t, 2, info["PUT http://elasticsearch:9200/_cluster/settings"])
+	require.EqualValues(t, 1, info["GET http://elasticsearch:9200/_cluster/settings"])
 	require.EqualValues(t, 1, info["GET http://elasticsearch:9200/_cat/shards"])
 
 	// Test that if ES endpoint stops responding as expected Drain will return an error

--- a/operator/es_client_test.go
+++ b/operator/es_client_test.go
@@ -37,7 +37,7 @@ func TestDrain(t *testing.T) {
 			PodIP: "1.2.3.4",
 		},
 	},
-		&RestyConfig{
+		&RetryConfig{
 			ClientRetryCount:       999,
 			ClientRetryWaitTime:    10 * time.Second,
 			ClientRetryMaxWaitTime: 30 * time.Second,
@@ -68,7 +68,7 @@ func TestDrain(t *testing.T) {
 			PodIP: "1.2.3.4",
 		},
 	},
-		&RestyConfig{
+		&RetryConfig{
 			ClientRetryCount:       1,
 			ClientRetryWaitTime:    1 * time.Second,
 			ClientRetryMaxWaitTime: 1 * time.Second,
@@ -316,7 +316,7 @@ func TestExcludeIP(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestRemoveFromExcludeIPList(t *testing.T) {
+func TestUndoExcludePodIP(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
@@ -348,7 +348,7 @@ func TestRemoveFromExcludeIPList(t *testing.T) {
 		Endpoint: url,
 	}
 
-	err := systemUnderTest.removeFromExcludeIPList(&v1.Pod{
+	err := systemUnderTest.undoExcludePodIP(&v1.Pod{
 		Status: v1.PodStatus{
 			PodIP: "192.168.1.2",
 		},

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -86,7 +86,7 @@ type StatefulResource interface {
 
 	// Drain drains a pod for data. It's expected that the method only
 	// returns after the pod has been drained.
-	Drain(ctx context.Context, pod *v1.Pod, config *RestyConfig) error
+	Drain(ctx context.Context, pod *v1.Pod, config *RetryConfig) error
 }
 
 // Operator is a generic operator that can manage Pods filtered by a selector.
@@ -96,7 +96,7 @@ type Operator struct {
 	interval              time.Duration
 	logger                *log.Entry
 	recorder              kube_record.EventRecorder
-	esClientRestyConfig   *RestyConfig
+	esClientRetryConfig   *RetryConfig
 }
 
 func (o *Operator) Run(ctx context.Context, done chan<- struct{}, sr StatefulResource) {
@@ -354,7 +354,7 @@ func (o *Operator) operatePods(ctx context.Context, sts *appsv1.StatefulSet, sr 
 	// drain Pod
 	o.recorder.Event(sr.Self(), v1.EventTypeNormal, "DrainingPod", fmt.Sprintf("Draining Pod '%s/%s'", pod.Namespace,
 		pod.Name))
-	err = sr.Drain(ctx, pod, o.esClientRestyConfig)
+	err = sr.Drain(ctx, pod, o.esClientRetryConfig)
 	if err != nil {
 		return fmt.Errorf("failed to drain Pod %s/%s: %v", pod.Namespace, pod.Name, err)
 	}
@@ -453,7 +453,7 @@ func (o *Operator) rescaleStatefulSet(ctx context.Context, sts *appsv1.StatefulS
 			}
 
 			log.Infof("Draining Pod %s/%s for scaledown", pod.Namespace, pod.Name)
-			err := sr.Drain(ctx, &pod, o.esClientRestyConfig)
+			err := sr.Drain(ctx, &pod, o.esClientRetryConfig)
 			if err != nil {
 				return fmt.Errorf("failed to drain pod %s/%s: %v", pod.Namespace, pod.Name, err)
 			}

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -86,7 +86,7 @@ type StatefulResource interface {
 
 	// Drain drains a pod for data. It's expected that the method only
 	// returns after the pod has been drained.
-	Drain(ctx context.Context, pod *v1.Pod) error
+	Drain(ctx context.Context, pod *v1.Pod, config *RestyConfig) error
 }
 
 // Operator is a generic operator that can manage Pods filtered by a selector.
@@ -96,6 +96,7 @@ type Operator struct {
 	interval              time.Duration
 	logger                *log.Entry
 	recorder              kube_record.EventRecorder
+	esClientRestyConfig   *RestyConfig
 }
 
 func (o *Operator) Run(ctx context.Context, done chan<- struct{}, sr StatefulResource) {
@@ -353,7 +354,7 @@ func (o *Operator) operatePods(ctx context.Context, sts *appsv1.StatefulSet, sr 
 	// drain Pod
 	o.recorder.Event(sr.Self(), v1.EventTypeNormal, "DrainingPod", fmt.Sprintf("Draining Pod '%s/%s'", pod.Namespace,
 		pod.Name))
-	err = sr.Drain(ctx, pod)
+	err = sr.Drain(ctx, pod, o.esClientRestyConfig)
 	if err != nil {
 		return fmt.Errorf("failed to drain Pod %s/%s: %v", pod.Namespace, pod.Name, err)
 	}
@@ -452,7 +453,7 @@ func (o *Operator) rescaleStatefulSet(ctx context.Context, sts *appsv1.StatefulS
 			}
 
 			log.Infof("Draining Pod %s/%s for scaledown", pod.Namespace, pod.Name)
-			err := sr.Drain(ctx, &pod)
+			err := sr.Drain(ctx, &pod, o.esClientRestyConfig)
 			if err != nil {
 				return fmt.Errorf("failed to drain pod %s/%s: %v", pod.Namespace, pod.Name, err)
 			}

--- a/operator/operator_test.go
+++ b/operator/operator_test.go
@@ -48,7 +48,7 @@ func (r *mockResource) EnsureResources(ctx context.Context) error               
 func (r *mockResource) UpdateStatus(ctx context.Context, sts *appsv1.StatefulSet) error   { return nil }
 func (r *mockResource) PreScaleDownHook(ctx context.Context) error                        { return nil }
 func (r *mockResource) OnStableReplicasHook(ctx context.Context) error                    { return nil }
-func (r *mockResource) Drain(ctx context.Context, pod *v1.Pod, config *RestyConfig) error { return nil }
+func (r *mockResource) Drain(ctx context.Context, pod *v1.Pod, config *RetryConfig) error { return nil }
 
 func TestPrioritizePodsForUpdate(t *testing.T) {
 	updatingPod := v1.Pod{

--- a/operator/operator_test.go
+++ b/operator/operator_test.go
@@ -43,12 +43,12 @@ func (r *mockResource) PodTemplateSpec() *v1.PodTemplateSpec { return r.podTempl
 func (r *mockResource) VolumeClaimTemplates() []v1.PersistentVolumeClaim {
 	return r.volumeClaimTemplates
 }
-func (r *mockResource) Self() runtime.Object                                            { return r.eds }
-func (r *mockResource) EnsureResources(ctx context.Context) error                       { return nil }
-func (r *mockResource) UpdateStatus(ctx context.Context, sts *appsv1.StatefulSet) error { return nil }
-func (r *mockResource) PreScaleDownHook(ctx context.Context) error                      { return nil }
-func (r *mockResource) OnStableReplicasHook(ctx context.Context) error                  { return nil }
-func (r *mockResource) Drain(ctx context.Context, pod *v1.Pod) error                    { return nil }
+func (r *mockResource) Self() runtime.Object                                              { return r.eds }
+func (r *mockResource) EnsureResources(ctx context.Context) error                         { return nil }
+func (r *mockResource) UpdateStatus(ctx context.Context, sts *appsv1.StatefulSet) error   { return nil }
+func (r *mockResource) PreScaleDownHook(ctx context.Context) error                        { return nil }
+func (r *mockResource) OnStableReplicasHook(ctx context.Context) error                    { return nil }
+func (r *mockResource) Drain(ctx context.Context, pod *v1.Pod, config *RestyConfig) error { return nil }
 
 func TestPrioritizePodsForUpdate(t *testing.T) {
 	updatingPod := v1.Pod{


### PR DESCRIPTION
# One-line summary

> Update Drain functionality

## Description
Add an ability to set parameters for retry logic with Resty lib.
Add handling for not finished shards migration.

### About shards migration and Drain behavior
We have a kinda bug in waitForEmptyEsNode function.
In this function, after we finish a retry logic we don't check the response and proceed with the deletion of the pod but it can be wrong (shards can be still on the pod). So validation for this case is added.

Also, an additional logic added with`removeFromExcludeIPList`. So if checking of remaining shards finishes without success now we remove the pod from the exclude list in ES cluster settings (before, it left in the excluded list).

There is the next idea behind it - ES-Op can change scaling direction after waiting for condition(migration of remaining shards from Pod) so it looks better to start with the state before Drain was started.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)

## Review
_List of tasks the reviewer must do to review the PR_
- [x] Tests

## Deployment Notes
To test this behavior ES-Op should be deployed with small values of retry logic options:
```
        - --esclient-retry-count=2
        - --esclient-retry-waittime=1s
        - --esclient-retry-max-waittime=10s
```
