### PR TITLE
Document spec.excludeSystemIndices

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ spec:
 | Key      | Description   | Type |
 |----------|---------------|---------|
 | spec.replicas | Initial size of the StatefulSet. If auto-scaling is disabled, this is your desired cluster size. | Int |
+| spec.excludeSystemIndices | Enable or disable inclusion of system indices like '.kibana' when calculating shard-per-node ratio and scaling index replica counts. Those are usually managed by Elasticsearch internally. Default is false for backwards compatibility | Boolean |
 | spec.scaling.enabled | Enable or disable auto-scaling. May be necessary to enforce manual scaling. | Boolean |
 | spec.scaling.minReplicas | Minimum Pod replicas. Lower bound (inclusive) when scaling down.  | Int |
 | spec.scaling.maxReplicas | Maximum Pod replicas. Upper bound (inclusive) when scaling up.  | Int |


### PR DESCRIPTION
Signed-off-by: Oliver Trosien <oliver.trosien@zalando.de>

# One-line summary

Introduced in https://github.com/zalando-incubator/es-operator/pull/177 but not documented in the README.

## Description

Exclude ES-Operator from managing system indices. This can be controlled per EDS. To avoid this being a breaking change, the default setting is opt-in.

Added an optional setting to the EDS (spec.excludeSystemIndices). If set to true, the ES-Operator will filter out indices starting with "." (indication of an internal Elasticsearch index) when calculating shard-per-node ratio and scaling index replica counts.

It will still check all shards, even ones for system indices when draining to make sure we don't terminte a node with data on it.


## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Documentation / non-code
