### PR TITLE
[bugfix] Ensure that empty transient string values are converted to null

### DIFF
--- a/operator/es_client_test.go
+++ b/operator/es_client_test.go
@@ -359,7 +359,6 @@ func TestESSettingsMergeNonEmtpyTransientSettings(t *testing.T) {
 				Transient: ClusterSettings{Cluster{Routing{Rebalance: Rebalance{Enable: null.StringFrom("none")}}}},
 			},
 			expected: ESSettings{
-				Transient:  ClusterSettings{Cluster{Routing{Rebalance: Rebalance{Enable: null.StringFromPtr(nil)}}}},
 				Persistent: ClusterSettings{Cluster{Routing{Rebalance: Rebalance{Enable: null.StringFrom("none")}}}},
 			},
 		},
@@ -369,9 +368,15 @@ func TestESSettingsMergeNonEmtpyTransientSettings(t *testing.T) {
 				Transient: ClusterSettings{Cluster{Routing{Allocation: Allocation{Exclude{IP: null.StringFrom("1.2.3.4")}}}}},
 			},
 			expected: ESSettings{
-				Transient:  ClusterSettings{Cluster{Routing{Allocation: Allocation{Exclude{IP: null.StringFromPtr(nil)}}}}},
 				Persistent: ClusterSettings{Cluster{Routing{Allocation: Allocation{Exclude{IP: null.StringFrom("1.2.3.4")}}}}},
 			},
+		},
+		{
+			name: "overwrite empty transient exclude ips string to null",
+			fields: fields{
+				Transient: ClusterSettings{Cluster{Routing{Allocation: Allocation{Exclude{IP: null.StringFrom("")}}}}},
+			},
+			expected: ESSettings{},
 		},
 		{
 			name: "merge existing persistent exclude ips with transient exclude ips",
@@ -380,7 +385,6 @@ func TestESSettingsMergeNonEmtpyTransientSettings(t *testing.T) {
 				Persistent: ClusterSettings{Cluster{Routing{Allocation: Allocation{Exclude{IP: null.StringFrom("11.21.31.41")}}}}},
 			},
 			expected: ESSettings{
-				Transient:  ClusterSettings{Cluster{Routing{Allocation: Allocation{Exclude{IP: null.StringFromPtr(nil)}}}}},
 				Persistent: ClusterSettings{Cluster{Routing{Allocation: Allocation{Exclude{IP: null.StringFrom("1.2.3.4,11.21.31.41")}}}}},
 			},
 		},
@@ -391,7 +395,6 @@ func TestESSettingsMergeNonEmtpyTransientSettings(t *testing.T) {
 				Persistent: ClusterSettings{Cluster{Routing{Allocation: Allocation{Exclude{IP: null.StringFrom("11.21.31.41")}}}}},
 			},
 			expected: ESSettings{
-				Transient:  ClusterSettings{Cluster{Routing{Allocation: Allocation{Exclude{IP: null.StringFromPtr(nil)}}}}},
 				Persistent: ClusterSettings{Cluster{Routing{Allocation: Allocation{Exclude{IP: null.StringFrom("1.2.3.4,11.21.31.41")}}}}},
 			},
 		},
@@ -404,7 +407,9 @@ func TestESSettingsMergeNonEmtpyTransientSettings(t *testing.T) {
 			}
 			esSettings.MergeNonEmptyTransientSettings()
 			assert.Equal(t, tt.expected.GetPersistentRebalance(), esSettings.GetPersistentRebalance())
+			assert.Equal(t, tt.expected.GetTransientRebalance(), esSettings.GetTransientRebalance())
 			assert.Equal(t, tt.expected.GetPersistentExcludeIPs(), esSettings.GetPersistentExcludeIPs())
+			assert.Equal(t, tt.expected.GetTransientExcludeIPs(), esSettings.GetTransientExcludeIPs())
 		})
 	}
 }


### PR DESCRIPTION
The empty string transient exclude ips list must be overwritten to a
null so that the setting is completely removed and the persistent setting
can take effect.

Signed-off-by: Girish Chandrashekar <girish.chandrashekar@zalando.de>

# One-line summary

The empty string value exclude ips settings is a valid value and needs to be set to null in
the transient key space to avoid overriding the setting in the persistent key space.

## Description
- Remove the logic that was skipping the overwrite to null on the transient exclude ip setting when the value was an empty string.
- One additional if statement to set the persistent exclude ip setting only if there is valid non empty transient value available. Without this the es-operator would always set the persistent exclude ips to the merged values or an empty string.
- Clean up some test cases that explicitly specified the expected null transient values.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)


## Tasks
None pending.

## Review
_List of tasks the reviewer must do to review the PR_
- [x] Tests
- [x] Documentation
- [x] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
