### PR TITLE
first pass at disk-based scale-up and down

### DIFF
--- a/docs/zalando.org_elasticsearchdatasets.yaml
+++ b/docs/zalando.org_elasticsearchdatasets.yaml
@@ -102,6 +102,10 @@ spec:
                     format: int64
                     minimum: 0
                     type: integer
+                  scaleDownDiskUsagePercentBoundary:
+                    format: int32
+                    minimum: 0
+                    type: integer
                   scaleDownThresholdDurationSeconds:
                     format: int64
                     minimum: 0
@@ -112,6 +116,10 @@ spec:
                     type: integer
                   scaleUpCooldownSeconds:
                     format: int64
+                    minimum: 0
+                    type: integer
+                  scaleUpDiskUsagePercentBoundary:
+                    format: int32
                     minimum: 0
                     type: integer
                   scaleUpThresholdDurationSeconds:

--- a/docs/zalando.org_elasticsearchdatasets_v1beta1.yaml
+++ b/docs/zalando.org_elasticsearchdatasets_v1beta1.yaml
@@ -103,6 +103,10 @@ spec:
                   format: int64
                   minimum: 0
                   type: integer
+                scaleDownDiskUsagePercentBoundary:
+                  format: int32
+                  minimum: 0
+                  type: integer
                 scaleDownThresholdDurationSeconds:
                   format: int64
                   minimum: 0
@@ -113,6 +117,10 @@ spec:
                   type: integer
                 scaleUpCooldownSeconds:
                   format: int64
+                  minimum: 0
+                  type: integer
+                scaleUpDiskUsagePercentBoundary:
+                  format: int32
                   minimum: 0
                   type: integer
                 scaleUpThresholdDurationSeconds:

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -155,6 +155,9 @@ type ElasticsearchDataSetScaling struct {
 	ScaleUpCPUBoundary int32 `json:"scaleUpCPUBoundary"`
 	// +kubebuilder:validation:Minimum=0
 	// +optional
+	ScaleUpDiskUsagePercentBoundary int32 `json:"scaleUpDiskUsagePercentBoundary"`
+	// +kubebuilder:validation:Minimum=0
+	// +optional
 	ScaleUpThresholdDurationSeconds int64 `json:"scaleUpThresholdDurationSeconds"`
 	// +kubebuilder:validation:Minimum=0
 	// +optional
@@ -162,6 +165,9 @@ type ElasticsearchDataSetScaling struct {
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	ScaleDownCPUBoundary int32 `json:"scaleDownCPUBoundary"`
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	ScaleDownDiskUsagePercentBoundary int32 `json:"scaleDownDiskUsagePercentBoundary"`
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	ScaleDownThresholdDurationSeconds int64 `json:"scaleDownThresholdDurationSeconds"`


### PR DESCRIPTION
# One-line summary

> Issue : #10

## Description
This is a first draft of disk-based scaling. I've tested it and it works if you add this to the `scaling` spec:
```
    scaleUpDiskUsagePercentBoundary: 10
    scaleDownDiskUsagePercentBoundary: 5
```

I've added the scale-up logic in the `scaleUpOrDown` function, so that we enforce it. I've added the scale-down logic to the `scalingHint` function, so that it's only a hint (e.g. if we have high CPU, we won't want to scale down).

## Types of Changes
- New feature (non-breaking change which adds functionality)
- Configuration change

This is yet to be done, but I'd like to get some feedback early:
- Documentation / non-code

## Tasks
  - [x] Initial PR
  - [ ] Iterate over feedback
  - [ ] Add docs
  - [ ] Add tests?

## Review
- [ ] Check the code
- [ ] CHANGELOG

## Deployment Notes
None that I'm aware of
