### PR TITLE
Integrate scale sub resouce by means of an HPA and ScheludedScaling CRD

### DIFF
--- a/docs/cluster-roles.yaml
+++ b/docs/cluster-roles.yaml
@@ -1,3 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: es-operator-demo
+  name: es-operator
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -24,7 +30,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - services
+    - services
   verbs:
   - get
   - list

--- a/docs/elasticsearch-cluster.yaml
+++ b/docs/elasticsearch-cluster.yaml
@@ -121,3 +121,24 @@ spec:
   ports:
   - name: transport
     port: 9300
+    targetPort: 9300
+  - name: http
+    port: 9200
+    targetPort: 9200
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  namespace: es-operator-demo
+spec:
+  selector:
+    application: elasticsearch
+    role: master
+  ports:
+    - name: transport
+      port: 9300
+      targetPort: 9300
+    - name: http
+      port: 9200
+      targetPort: 9200

--- a/docs/elasticsearchdataset-simple.yaml
+++ b/docs/elasticsearchdataset-simple.yaml
@@ -6,11 +6,24 @@ metadata:
     role: data
     group: simple
   name: es-data-simple
-  namespace: es-operator-demo
 spec:
   replicas: 1
+  hpa_replicas: 1
   scaling:
-    enabled: false
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 3
+    minIndexReplicas: 0
+    maxIndexReplicas: 0
+    minShardsPerNode: 1
+    maxShardsPerNode: 4
+    scaleUpCPUBoundary: 90
+    scaleUpThresholdDurationSeconds: 300
+    scaleUpCooldownSeconds: 300
+    scaleDownCPUBoundary: 80
+    scaleDownThresholdDurationSeconds: 300
+    scaleDownCooldownSeconds: 300
+    diskUsagePercentScaledownWatermark: 90
   template:
     metadata:
       labels:
@@ -21,65 +34,66 @@ spec:
       securityContext:
         fsGroup: 1000
       containers:
-      - name: elasticsearch
-        env:
-        - name: "node.name"
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: "node.attr.group"
-          value: "simple"
-        - name: "node.master"
-          value: "false"
-        - name: "node.data"
-          value: "true"
-        - name: "ES_JAVA_OPTS"
-          value: "-Xmx500m -Xms500m"
-        image: "docker.elastic.co/elasticsearch/elasticsearch-oss:7.0.0"
-        ports:
-        - containerPort: 9300
-          name: transport
-        readinessProbe:
-          httpGet:
-            path: /_cat/master
-            port: 9200
-          timeoutSeconds: 10
-        resources:
-          limits:
-            cpu: 100m
-            memory: 800Mi
-          requests:
-            cpu: 100m
-            memory: 800Mi
-        volumeMounts:
-        - mountPath: /usr/share/elasticsearch/data
-          name: data
-        - name: elasticsearch-config
-          mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
-          subPath: elasticsearch.yml
+        - name: elasticsearch
+          env:
+            - name: "node.name"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: "node.attr.group"
+              value: "simple"
+            - name: "node.master"
+              value: "false"
+            - name: "node.data"
+              value: "true"
+            - name: "ES_JAVA_OPTS"
+              value: "-Xmx500m -Xms500m"
+          image: "docker.elastic.co/elasticsearch/elasticsearch-oss:7.0.0"
+          ports:
+            - containerPort: 9300
+              name: transport
+          readinessProbe:
+            httpGet:
+              path: /_cat/master
+              port: 9200
+            timeoutSeconds: 10
+            initialDelaySeconds: 120
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1000Mi
+            requests:
+              cpu: 1000m
+              memory: 1000Mi
+          volumeMounts:
+            - mountPath: /usr/share/elasticsearch/data
+              name: data
+            - name: elasticsearch-config
+              mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
+              subPath: elasticsearch.yml
       initContainers:
-      - command:
-        - sysctl
-        - -w
-        - vm.max_map_count=262144
-        image: busybox:1.30
-        name: init-sysctl
-        resources:
-          limits:
-            cpu: 50m
-            memory: 50Mi
-          requests:
-            cpu: 50m
-            memory: 50Mi
-        securityContext:
-          runAsUser: 0
-          privileged: true
+        - command:
+            - sysctl
+            - -w
+            - vm.max_map_count=262144
+          image: busybox:1.30
+          name: init-sysctl
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50Mi
+            requests:
+              cpu: 50m
+              memory: 50Mi
+          securityContext:
+            runAsUser: 0
+            privileged: true
       volumes:
-      - name: data
-        emptyDir: {}
-      - name: elasticsearch-config
-        configMap:
-          name: es-config
-          items:
-          - key: elasticsearch.yml
-            path: elasticsearch.yml
+        - name: data
+          emptyDir: { }
+        - name: elasticsearch-config
+          configMap:
+            name: es-config
+            items:
+              - key: elasticsearch.yml
+                path: elasticsearch.yml

--- a/docs/es-operator.yaml
+++ b/docs/es-operator.yaml
@@ -33,7 +33,11 @@ spec:
       serviceAccountName: es-operator
       containers:
       - name: es-operator
-        image: registry.opensource.zalan.do/poirot/es-operator:latest
+        image: es-operator-local:v0.1.3-21-g4ad2302-dirty
+        args:
+          - --interval=30s
+          - --namespace=es-operator-demo
+          - --debug
         resources:
           limits:
             cpu: 20m

--- a/docs/hpa.yaml
+++ b/docs/hpa.yaml
@@ -1,0 +1,26 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: "es-data-simple-hpa"
+  namespace: "es-operator-demo"
+  labels:
+    application: "elasticsearch"
+spec:
+  scaleTargetRef:
+    apiVersion: zalando.org/v1
+    kind: ElasticsearchDataSet
+    name: es-data-simple
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Object
+      object:
+        describedObject:
+          apiVersion: zalando.org/v1
+          kind: ScalingSchedule
+          name: "es-data-simple-scaleup-schedule"
+        metric:
+          name: "es-data-simple-scaleup-schedule"
+        target:
+          type: AverageValue
+          averageValue: "1000"

--- a/docs/scaling_schedule.yaml
+++ b/docs/scaling_schedule.yaml
@@ -1,0 +1,10 @@
+apiVersion: zalando.org/v1
+kind: ScalingSchedule
+metadata:
+  name: "es-data-simple-scaleup-schedule"
+spec:
+  schedules:
+    - type: OneTime
+      date: "2022-07-22T18:39:00+02:00"
+      durationMinutes: 8
+      value: 2000

--- a/docs/zalando.org_clusterscalingschedules.yaml
+++ b/docs/zalando.org_clusterscalingschedules.yaml
@@ -1,0 +1,124 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: clusterscalingschedules.zalando.org
+spec:
+  group: zalando.org
+  names:
+    kind: ClusterScalingSchedule
+    listKind: ClusterScalingScheduleList
+    plural: clusterscalingschedules
+    singular: clusterscalingschedule
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterScalingSchedule describes a cluster scoped time based
+          metric to be used in autoscaling operations.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ScalingScheduleSpec is the spec part of the ScalingSchedule.
+            properties:
+              scalingWindowDurationMinutes:
+                description: Fade the scheduled values in and out over this many minutes.
+                  If unset, the default per-cluster value will be used.
+                format: int64
+                type: integer
+              schedules:
+                description: Schedules is the list of schedules for this ScalingSchedule
+                  resource. All the schedules defined here will result on the value
+                  to the same metric. New metrics require a new ScalingSchedule resource.
+                items:
+                  description: Schedule is the schedule details to be used inside
+                    a ScalingSchedule.
+                  properties:
+                    date:
+                      description: Defines the starting date of a OneTime schedule.
+                        It has to be a RFC3339 formated date.
+                      format: date-time
+                      type: string
+                    durationMinutes:
+                      description: The duration in minutes that the configured value
+                        will be returned for the defined schedule.
+                      type: integer
+                    period:
+                      description: Defines the details of a Repeating schedule.
+                      properties:
+                        days:
+                          description: The days that this schedule will be active.
+                          items:
+                            description: ScheduleDay represents the valid inputs for
+                              days in a SchedulePeriod.
+                            enum:
+                            - Sun
+                            - Mon
+                            - Tue
+                            - Wed
+                            - Thu
+                            - Fri
+                            - Sat
+                            type: string
+                          type: array
+                        startTime:
+                          description: The startTime has the format HH:MM
+                          pattern: (([0-1][0-9])|([2][0-3])):([0-5][0-9])
+                          type: string
+                        timezone:
+                          description: The location name corresponding to a file in
+                            the IANA Time Zone database, like Europe/Berlin.
+                          type: string
+                      required:
+                      - days
+                      - startTime
+                      - timezone
+                      type: object
+                    type:
+                      description: Defines if the schedule is a OneTime schedule or
+                        Repeating one. If OneTime, date has to be defined. If Repeating,
+                        Period has to be defined.
+                      enum:
+                      - OneTime
+                      - Repeating
+                      type: string
+                    value:
+                      description: The metric value that will be returned for the
+                        defined schedule.
+                      format: int64
+                      type: integer
+                  required:
+                  - durationMinutes
+                  - type
+                  - value
+                  type: object
+                type: array
+            required:
+            - schedules
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/docs/zalando.org_elasticsearchdatasets.yaml
+++ b/docs/zalando.org_elasticsearchdatasets.yaml
@@ -55,6 +55,10 @@ spec:
                 description: Exclude management of System Indices on this Data Set.
                   Defaults to false
                 type: boolean
+              hpa_replicas:
+                description: Number of pods specified by the HPA.
+                format: int32
+                type: integer
               replicas:
                 description: Number of desired pods. This is a pointer to distinguish
                   between explicit zero and not specified. Defaults to 1.
@@ -6963,6 +6967,11 @@ spec:
             description: ElasticsearchDataSetStatus is the status section of the ElasticsearchDataSet
               resource.
             properties:
+              hpa_replicas:
+                description: HpaReplicas is the number of Pods determined by the HPA
+                  metrics.
+                format: int32
+                type: integer
               lastScaleDownEnded:
                 format: date-time
                 type: string
@@ -6985,8 +6994,13 @@ spec:
                 description: Replicas is the number of Pods by the underlying StatefulSet.
                 format: int32
                 type: integer
+              selector:
+                description: Hpa selector
+                type: string
             required:
+            - hpa_replicas
             - replicas
+            - selector
             type: object
         required:
         - spec
@@ -6994,6 +7008,10 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.hpa_replicas
+        statusReplicasPath: .status.hpa_replicas
       status: {}
 status:
   acceptedNames:

--- a/docs/zalando.org_elasticsearchdatasets_v1beta1.yaml
+++ b/docs/zalando.org_elasticsearchdatasets_v1beta1.yaml
@@ -30,6 +30,10 @@ spec:
   preserveUnknownFields: false
   scope: Namespaced
   subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.hpa_replicas
+      statusReplicasPath: .status.hpa_replicas
     status: {}
   validation:
     openAPIV3Schema:
@@ -56,6 +60,10 @@ spec:
               description: Exclude management of System Indices on this Data Set.
                 Defaults to false
               type: boolean
+            hpa_replicas:
+              description: Number of pods specified by the HPA.
+              format: int32
+              type: integer
             replicas:
               description: Number of desired pods. This is a pointer to distinguish
                 between explicit zero and not specified. Defaults to 1.
@@ -6811,6 +6819,11 @@ spec:
           description: ElasticsearchDataSetStatus is the status section of the ElasticsearchDataSet
             resource.
           properties:
+            hpa_replicas:
+              description: HpaReplicas is the number of Pods determined by the HPA
+                metrics.
+              format: int32
+              type: integer
             lastScaleDownEnded:
               format: date-time
               type: string
@@ -6833,8 +6846,13 @@ spec:
               description: Replicas is the number of Pods by the underlying StatefulSet.
               format: int32
               type: integer
+            selector:
+              description: Hpa selector
+              type: string
           required:
+          - hpa_replicas
           - replicas
+          - selector
           type: object
       required:
       - spec

--- a/docs/zalando.org_scalingschedules.yaml
+++ b/docs/zalando.org_scalingschedules.yaml
@@ -1,0 +1,128 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: scalingschedules.zalando.org
+spec:
+  conversion:
+    strategy: None
+  group: zalando.org
+  names:
+    kind: ScalingSchedule
+    listKind: ScalingScheduleList
+    plural: scalingschedules
+    singular: scalingschedule
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ScalingSchedule describes a namespaced time based metric to be
+            used in autoscaling operations.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ScalingScheduleSpec is the spec part of the ScalingSchedule.
+              properties:
+                scalingWindowDurationMinutes:
+                  description: Fade the scheduled values in and out over this many minutes.
+                    If unset, the default per-cluster value will be used.
+                  format: int64
+                  type: integer
+                schedules:
+                  description: Schedules is the list of schedules for this ScalingSchedule
+                    resource. All the schedules defined here will result on the value
+                    to the same metric. New metrics require a new ScalingSchedule resource.
+                  items:
+                    description: Schedule is the schedule details to be used inside
+                      a ScalingSchedule.
+                    properties:
+                      date:
+                        description: Defines the starting date of a OneTime schedule.
+                          It has to be a RFC3339 formated date.
+                        format: date-time
+                        type: string
+                      durationMinutes:
+                        description: The duration in minutes that the configured value
+                          will be returned for the defined schedule.
+                        type: integer
+                      period:
+                        description: Defines the details of a Repeating schedule.
+                        properties:
+                          days:
+                            description: The days that this schedule will be active.
+                            items:
+                              description: ScheduleDay represents the valid inputs for
+                                days in a SchedulePeriod.
+                              enum:
+                                - Sun
+                                - Mon
+                                - Tue
+                                - Wed
+                                - Thu
+                                - Fri
+                                - Sat
+                              type: string
+                            type: array
+                          startTime:
+                            description: The startTime has the format HH:MM
+                            pattern: (([0-1][0-9])|([2][0-3])):([0-5][0-9])
+                            type: string
+                          timezone:
+                            description: The location name corresponding to a file in
+                              the IANA Time Zone database, like Europe/Berlin.
+                            type: string
+                        required:
+                          - days
+                          - startTime
+                          - timezone
+                        type: object
+                      type:
+                        description: Defines if the schedule is a OneTime schedule or
+                          Repeating one. If OneTime, date has to be defined. If Repeating,
+                          Period has to be defined.
+                        enum:
+                          - OneTime
+                          - Repeating
+                        type: string
+                      value:
+                        description: The metric value that will be returned for the
+                          defined schedule.
+                        format: int64
+                        type: integer
+                    required:
+                      - durationMinutes
+                      - type
+                      - value
+                    type: object
+                  type: array
+              required:
+                - schedules
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ScalingSchedule
+    listKind: ScalingScheduleList
+    plural: scalingschedules
+    singular: scalingschedule
+  conditions: [ ]
+  storedVersions:
+    - v1

--- a/manifests/kube-metrics-adapter.yaml
+++ b/manifests/kube-metrics-adapter.yaml
@@ -1,0 +1,244 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: custom-metrics-apiserver
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: custom-metrics-server-resources
+rules:
+- apiGroups:
+  - custom.metrics.k8s.io
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-metrics-server-resources
+rules:
+- apiGroups:
+  - external.metrics.k8s.io
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: custom-metrics-resource-reader
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: custom-metrics-resource-collector
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - get
+# only relevant if running with the flag:
+# --skipper-ingress-metrics
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+# only relevant if running with the flag:
+# --skipper-routegroup-metrics
+- apiGroups:
+  - zalando.org
+  resources:
+  - routegroups
+  verbs:
+  - get
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - zalando.org
+  resources:
+  - clusterscalingschedules
+  - scalingschedules
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hpa-controller-custom-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: custom-metrics-server-resources
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hpa-controller-external-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-metrics-server-resources
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: custom-metrics-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: custom-metrics-apiserver
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: custom-metrics:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: custom-metrics-apiserver
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: custom-metrics-resource-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: custom-metrics-resource-collector
+subjects:
+- kind: ServiceAccount
+  name: custom-metrics-apiserver
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-metrics-adapter
+  namespace: kube-system
+  labels:
+    application: kube-metrics-adapter
+    version: latest
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: kube-metrics-adapter
+  template:
+    metadata:
+      labels:
+        application: kube-metrics-adapter
+        version: latest
+      annotations:
+        iam.amazonaws.com/role: "kube-aws-test-1-app-zmon"
+    spec:
+      serviceAccountName: custom-metrics-apiserver
+      containers:
+      - name: kube-metrics-adapter
+        image: registry.opensource.zalan.do/teapot/kube-metrics-adapter:latest
+        args:
+        - --scaling-schedule
+        env:
+        - name: AWS_REGION
+          value: eu-central-1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-metrics-adapter
+  namespace: kube-system
+spec:
+  ports:
+  - port: 443
+    targetPort: 443
+  selector:
+    application: kube-metrics-adapter
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.custom.metrics.k8s.io
+spec:
+  service:
+    name: kube-metrics-adapter
+    namespace: kube-system
+  group: custom.metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.external.metrics.k8s.io
+spec:
+  service:
+    name: kube-metrics-adapter
+    namespace: kube-system
+  group: external.metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100
+---

--- a/manifests/metrics-server.yaml
+++ b/manifests/metrics-server.yaml
@@ -16,15 +16,15 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: system:aggregated-metrics-reader
 rules:
-- apiGroups:
-  - metrics.k8s.io
-  resources:
-  - pods
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -33,18 +33,18 @@ metadata:
     k8s-app: metrics-server
   name: system:metrics-server
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - nodes/stats
-  - namespaces
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+      - nodes/stats
+      - namespaces
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -58,9 +58,9 @@ roleRef:
   kind: Role
   name: extension-apiserver-authentication-reader
 subjects:
-- kind: ServiceAccount
-  name: metrics-server
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -73,9 +73,9 @@ roleRef:
   kind: ClusterRole
   name: system:auth-delegator
 subjects:
-- kind: ServiceAccount
-  name: metrics-server
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -88,9 +88,9 @@ roleRef:
   kind: ClusterRole
   name: system:metrics-server
 subjects:
-- kind: ServiceAccount
-  name: metrics-server
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
 ---
 apiVersion: v1
 kind: Service
@@ -101,10 +101,10 @@ metadata:
   namespace: kube-system
 spec:
   ports:
-  - name: https
-    port: 443
-    protocol: TCP
-    targetPort: https
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
   selector:
     k8s-app: metrics-server
 ---
@@ -128,47 +128,47 @@ spec:
         k8s-app: metrics-server
     spec:
       containers:
-      - args:
-        - --cert-dir=/tmp
-        - --secure-port=4443
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
-        - --kubelet-use-node-status-port
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.4.2
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /livez
-            port: https
-            scheme: HTTPS
-          periodSeconds: 10
-        name: metrics-server
-        ports:
-        - containerPort: 4443
-          name: https
-          protocol: TCP
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /readyz
-            port: https
-            scheme: HTTPS
-          periodSeconds: 10
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 1000
-        volumeMounts:
-        - mountPath: /tmp
-          name: tmp-dir
+        - args:
+            - --cert-dir=/tmp
+            - --secure-port=4443
+            - --kubelet-insecure-tls
+            - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+            - --kubelet-use-node-status-port
+          image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: https
+              scheme: HTTPS
+            periodSeconds: 10
+          name: metrics-server
+          ports:
+            - containerPort: 4443
+              name: https
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: https
+              scheme: HTTPS
+            periodSeconds: 10
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp-dir
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
       volumes:
-      - emptyDir: {}
-        name: tmp-dir
+        - emptyDir: { }
+          name: tmp-dir
 ---
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
@@ -185,3 +185,4 @@ spec:
     namespace: kube-system
   version: v1beta1
   versionPriority: 100
+---

--- a/operator/autoscaler_test.go
+++ b/operator/autoscaler_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestScalingHint(t *testing.T) {
+	replicas := int32(1)
+	hpaReplicas := int32(1)
 	eds := &zv1.ElasticsearchDataSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "EDS1",
@@ -25,6 +27,8 @@ func TestScalingHint(t *testing.T) {
 				ScaleDownCPUBoundary:              25,
 				ScaleDownThresholdDurationSeconds: 240,
 			},
+			Replicas:    &replicas,
+			HpaReplicas: &hpaReplicas,
 		},
 		Status: zv1.ElasticsearchDataSetStatus{},
 	}
@@ -140,7 +144,7 @@ func TestScalingHint(t *testing.T) {
 }
 
 func TestScaleUp(t *testing.T) {
-	eds := edsTestFixture(4)
+	eds := edsTestFixture(4, 0)
 	esNodes := make([]ESNode, 0)
 
 	// scale up
@@ -157,7 +161,7 @@ func TestScaleUp(t *testing.T) {
 }
 
 func TestScaleUpByAddingReplicas(t *testing.T) {
-	eds := edsTestFixture(4)
+	eds := edsTestFixture(4, 0)
 	esNodes := make([]ESNode, 0)
 
 	// scale up by adding replicas
@@ -175,7 +179,7 @@ func TestScaleUpByAddingReplicas(t *testing.T) {
 }
 
 func TestScaleUpSnappingToNonFractionedShardToNodeRatio(t *testing.T) {
-	eds := edsTestFixture(5)
+	eds := edsTestFixture(5, 0)
 	esNodes := make([]ESNode, 0)
 
 	// scale up by adding replicas
@@ -192,7 +196,7 @@ func TestScaleUpSnappingToNonFractionedShardToNodeRatio(t *testing.T) {
 }
 
 func TestScaleDownSnappingToNonFractionedShardToNodeRatio(t *testing.T) {
-	eds := edsTestFixture(14)
+	eds := edsTestFixture(14, 0)
 	esNodes := make([]ESNode, 0)
 
 	esIndices := map[string]ESIndex{
@@ -209,7 +213,7 @@ func TestScaleDownSnappingToNonFractionedShardToNodeRatio(t *testing.T) {
 }
 
 func TestScaleDown(t *testing.T) {
-	eds := edsTestFixture(4)
+	eds := edsTestFixture(4, 0)
 	esNodes := make([]ESNode, 0)
 
 	// scale down
@@ -226,7 +230,7 @@ func TestScaleDown(t *testing.T) {
 }
 
 func TestScaleDownToLowestBoundary(t *testing.T) {
-	eds := edsTestFixture(4)
+	eds := edsTestFixture(4, 0)
 	eds.Spec.Scaling.MaxShardsPerNode = 40
 
 	esNodes := make([]ESNode, 0)
@@ -249,7 +253,7 @@ func TestScaleDownToLowestBoundary(t *testing.T) {
 }
 
 func TestCannotScaleDownAnymore(t *testing.T) {
-	eds := edsTestFixture(4)
+	eds := edsTestFixture(4, 0)
 	esNodes := make([]ESNode, 0)
 
 	// cannot scale down anymore
@@ -267,7 +271,7 @@ func TestCannotScaleDownAnymore(t *testing.T) {
 }
 
 func TestIncreaseShardToNodeRatioMore(t *testing.T) {
-	eds := edsTestFixture(3)
+	eds := edsTestFixture(3, 0)
 	esNodes := make([]ESNode, 0)
 
 	// scale-down even if this means increasing shard-to-node ratio of more than +1
@@ -287,7 +291,7 @@ func TestIncreaseShardToNodeRatioMore(t *testing.T) {
 }
 
 func TestScaleDownByRemovingIndexReplica(t *testing.T) {
-	eds := edsTestFixture(4)
+	eds := edsTestFixture(4, 0)
 	esNodes := make([]ESNode, 0)
 
 	// scale down by removing an index replica
@@ -305,7 +309,7 @@ func TestScaleDownByRemovingIndexReplica(t *testing.T) {
 }
 
 func TestAtMaxIndexReplicas(t *testing.T) {
-	eds := edsTestFixture(4)
+	eds := edsTestFixture(4, 0)
 	esNodes := make([]ESNode, 0)
 
 	// cannot scale up further (already at maxIndexReplicas)
@@ -323,7 +327,7 @@ func TestAtMaxIndexReplicas(t *testing.T) {
 }
 
 func TestScaleUpCausedByShardToNodeRatioExceeded(t *testing.T) {
-	eds := edsTestFixture(4)
+	eds := edsTestFixture(4, 0)
 	esNodes := make([]ESNode, 0)
 
 	// require to scale-up because we exceeded shard-to-node ratio limits.
@@ -343,7 +347,7 @@ func TestScaleUpCausedByShardToNodeRatioExceeded(t *testing.T) {
 }
 
 func TestScaleUpCausedByShardToNodeRatioLessThanOne(t *testing.T) {
-	eds := edsTestFixture(11)
+	eds := edsTestFixture(11, 0)
 	esNodes := make([]ESNode, 0)
 
 	// require to scale-up index replicas because we are below one shard per node.
@@ -367,7 +371,7 @@ func TestScaleUpCausedByShardToNodeRatioLessThanOne(t *testing.T) {
 }
 
 func TestAtMaxShardsPerNode(t *testing.T) {
-	eds := edsTestFixture(4)
+	eds := edsTestFixture(4, 0)
 	esNodes := make([]ESNode, 0)
 
 	esIndices := map[string]ESIndex{
@@ -393,7 +397,7 @@ func TestAtMaxShardsPerNode(t *testing.T) {
 }
 
 func TestScaleMinIndexReplicas(t *testing.T) {
-	eds := edsTestFixture(4)
+	eds := edsTestFixture(4, 0)
 	esNodes := make([]ESNode, 0)
 
 	// scale up indexReplicas to 2 despite of scalingHint == DOWN
@@ -416,7 +420,7 @@ func TestScaleMinIndexReplicas(t *testing.T) {
 }
 
 func TestAtMinIndexReplicas(t *testing.T) {
-	eds := edsTestFixture(4)
+	eds := edsTestFixture(4, 0)
 	esNodes := make([]ESNode, 0)
 
 	// don't scale down if that would cause to have less data nodes then min index replicas
@@ -438,7 +442,7 @@ func TestAtMinIndexReplicas(t *testing.T) {
 }
 
 func TestAtNoIndicesAllocatedYet(t *testing.T) {
-	eds := edsTestFixture(4)
+	eds := edsTestFixture(4, 0)
 	esIndices := make(map[string]ESIndex)
 	esNodes := make([]ESNode, 0)
 
@@ -457,7 +461,7 @@ func TestAtNoIndicesAllocatedYet(t *testing.T) {
 }
 
 func TestAtMinReplicas(t *testing.T) {
-	eds := edsTestFixture(4)
+	eds := edsTestFixture(4, 0)
 	esNodes := make([]ESNode, 0)
 
 	// don't scale down if we reached MinReplicas
@@ -480,7 +484,7 @@ func TestAtMinReplicas(t *testing.T) {
 }
 
 func TestAtMaxReplicas(t *testing.T) {
-	eds := edsTestFixture(4)
+	eds := edsTestFixture(4, 0)
 	esNodes := make([]ESNode, 0)
 
 	// don't scale down if we reached MinReplicas
@@ -503,7 +507,7 @@ func TestAtMaxReplicas(t *testing.T) {
 }
 
 func TestAtMaxDisk(t *testing.T) {
-	eds := edsTestFixture(4)
+	eds := edsTestFixture(4, 0)
 	esNodes := []ESNode{
 		{
 			IP:              "1.2.3.4",
@@ -544,9 +548,11 @@ func TestEDSWithoutReplicas(t *testing.T) {
 	require.Equal(t, actual.ScalingDirection, NONE, actual.Description)
 }
 
-func edsTestFixture(initialReplicas int) *zv1.ElasticsearchDataSet {
+func edsTestFixture(initialReplicas int, initialHpaReplicas int) *zv1.ElasticsearchDataSet {
 	r := int32(initialReplicas)
-	return &zv1.ElasticsearchDataSet{
+	hpaReplicas := int32(initialHpaReplicas)
+
+	eds := &zv1.ElasticsearchDataSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "EDS1",
 			Namespace: "default",
@@ -558,14 +564,22 @@ func edsTestFixture(initialReplicas int) *zv1.ElasticsearchDataSet {
 				MinIndexReplicas:                   1,
 				MaxIndexReplicas:                   3,
 				DiskUsagePercentScaledownWatermark: 75,
+				ScaleUpCooldownSeconds:             120,
+				ScaleUpCPUBoundary:                 50,
+				ScaleUpThresholdDurationSeconds:    240,
+				ScaleDownCooldownSeconds:           120,
+				ScaleDownCPUBoundary:               25,
+				ScaleDownThresholdDurationSeconds:  240,
 			},
-			Replicas: &r,
+			Replicas:    &r,
+			HpaReplicas: &hpaReplicas,
 		},
 	}
+	return eds
 }
 
 func TestCalculateNodeBoundaries(t *testing.T) {
-	eds := edsTestFixture(3)
+	eds := edsTestFixture(3, 0)
 	eds.Spec.Scaling.MinReplicas = 2
 	eds.Spec.Scaling.MaxReplicas = 5
 	as := systemUnderTest(eds, nil, nil)
@@ -644,7 +658,7 @@ func TestGetManagedIndices(t *testing.T) {
 		},
 	}
 
-	as := systemUnderTest(edsTestFixture(1), nil, pods)
+	as := systemUnderTest(edsTestFixture(1, 0), nil, pods)
 	actual := as.getManagedIndices(indices, shards)
 
 	require.Equal(t, 2, len(actual))
@@ -672,7 +686,7 @@ func TestGetManagedNodes(t *testing.T) {
 		},
 	}
 
-	as := systemUnderTest(edsTestFixture(1), nil, pods)
+	as := systemUnderTest(edsTestFixture(1, 0), nil, pods)
 	actual := as.getManagedNodes(pods, nodes)
 
 	require.Equal(t, 1, len(actual))
@@ -686,4 +700,204 @@ func systemUnderTest(eds *zv1.ElasticsearchDataSet, metricSet *zv1.Elasticsearch
 		Pods:                 pods,
 	}
 	return NewAutoScaler(es, time.Second*60, nil)
+}
+
+func TestHpaScaleUpWithoutIndices(t *testing.T) {
+	eds := edsTestFixture(1, 1)
+	as := systemUnderTest(eds, nil, nil)
+
+	initialOperation := as.calculateScalingOperation(map[string]ESIndex{}, make([]ESNode, 0), NONE)
+	require.Nil(t, initialOperation.NodeReplicas, initialOperation.Description)
+	require.Equal(t, NONE, initialOperation.ScalingDirection, initialOperation.Description)
+
+	*eds.Spec.HpaReplicas = int32(3)
+
+	secondOperation := as.calculateScalingOperation(map[string]ESIndex{}, make([]ESNode, 0), UP)
+	require.Nil(t, secondOperation.NodeReplicas, secondOperation.Description)
+	require.Equal(t, NONE, secondOperation.ScalingDirection, secondOperation.Description)
+}
+
+func TestHpaScaleUpPreferMinNodeReplicasScaling(t *testing.T) {
+	eds := edsTestFixture(1, 1)
+	esIndices := map[string]ESIndex{
+		"ad1": {Replicas: 3, Primaries: 1, Index: "ad1"},
+	}
+	as := systemUnderTest(eds, nil, nil)
+
+	// ensure min node replicas for the index
+	initialOperation := as.calculateScalingOperation(esIndices, make([]ESNode, 0), UP)
+	require.Equal(t, int32(2), *initialOperation.NodeReplicas, initialOperation.Description)
+	require.Equal(t, UP, initialOperation.ScalingDirection, initialOperation.Description)
+
+	*eds.Spec.HpaReplicas = int32(10)
+
+	// satisfy hpa replicas
+	secondOperation := as.calculateScalingOperation(esIndices, make([]ESNode, 0), UP)
+	require.Equal(t, int32(10), *secondOperation.NodeReplicas, initialOperation.Description)
+	require.Equal(t, UP, secondOperation.ScalingDirection, secondOperation.Description)
+}
+
+func TestPreferScalingIndexReplicasOverHpaScaleUp(t *testing.T) {
+	eds := edsTestFixture(1, 1)
+	esIndices := map[string]ESIndex{
+		"ad1": {Replicas: 1, Primaries: 1, Index: "ad1"},
+	}
+	as := systemUnderTest(eds, nil, nil)
+
+	// ensure min node replicas
+	initialOperation := as.calculateScalingOperation(esIndices, make([]ESNode, 0), UP)
+	require.Equal(t, int32(2), *initialOperation.NodeReplicas, initialOperation.Description)
+	require.Equal(t, UP, initialOperation.ScalingDirection, initialOperation.Description)
+
+	eds.Spec.Scaling.MinIndexReplicas = int32(2)
+	*eds.Spec.HpaReplicas = int32(10)
+
+	// satisfy index replicas
+	secondOperation := as.calculateScalingOperation(esIndices, make([]ESNode, 0), UP)
+	require.Nil(t, secondOperation.NodeReplicas, secondOperation.Description)
+	require.Equal(t, UP, secondOperation.ScalingDirection, secondOperation.Description)
+	require.Equal(t, 1, len(secondOperation.IndexReplicas), secondOperation.Description)
+	require.Equal(t, int32(2), secondOperation.IndexReplicas[0].Replicas, secondOperation.Description)
+
+	// satisfy hpa replicas
+	scaledIndices := map[string]ESIndex{
+		"ad1": {Replicas: 2, Primaries: 1, Index: "ad1"},
+	}
+	thirdOperation := as.calculateScalingOperation(scaledIndices, make([]ESNode, 0), UP)
+	require.Equal(t, int32(10), *thirdOperation.NodeReplicas, thirdOperation.Description)
+	require.Equal(t, UP, thirdOperation.ScalingDirection, thirdOperation.Description)
+	require.Equal(t, 0, len(thirdOperation.IndexReplicas), thirdOperation.Description)
+}
+
+func buildEDSCpuMetrics(cpuUsage int32) *zv1.ElasticsearchMetricSet {
+	esMSet := &zv1.ElasticsearchMetricSet{
+		Metrics: []zv1.ElasticsearchMetric{
+			{
+				Timestamp: metav1.Now(),
+				Value:     cpuUsage,
+			},
+		},
+	}
+	esMSet.Metrics = []zv1.ElasticsearchMetric{
+		{
+			Timestamp: metav1.Now(),
+			Value:     cpuUsage,
+		},
+		{
+			Timestamp: metav1.Now(),
+			Value:     cpuUsage,
+		},
+		{
+			Timestamp: metav1.Now(),
+			Value:     cpuUsage,
+		},
+		{
+			Timestamp: metav1.Now(),
+			Value:     cpuUsage,
+		},
+	}
+	return esMSet
+}
+
+func TestHpaScaleUpSingleStep(t *testing.T) {
+	eds := edsTestFixture(3, 1)
+
+	esIndices := map[string]ESIndex{
+		"ad1": {Replicas: 1, Primaries: 2, Index: "ad1"},
+	}
+	esMSet := buildEDSCpuMetrics(int32(20))
+	as := systemUnderTest(eds, esMSet, nil)
+	*eds.Spec.HpaReplicas = int32(10)
+
+	var scalingHint = as.scalingHint()
+	require.Equal(t, scalingHint, UP)
+	initialOperation := as.calculateScalingOperation(esIndices, make([]ESNode, 0), scalingHint)
+	require.Equal(t, int32(10), *initialOperation.NodeReplicas, initialOperation.Description)
+	require.Equal(t, UP, initialOperation.ScalingDirection, initialOperation.Description)
+}
+
+func TestMaintainHpaReplicasWithLowCpu(t *testing.T) {
+	eds := edsTestFixture(10, 10)
+	esIndices := map[string]ESIndex{
+		"ad1": {Replicas: 1, Primaries: 1, Index: "ad1"},
+	}
+	esMSet := buildEDSCpuMetrics(int32(20))
+	as := systemUnderTest(eds, esMSet, nil)
+
+	scalingHint := as.scalingHint()
+	require.Equal(t, NONE, scalingHint)
+
+	scalingOperation := as.calculateScalingOperation(esIndices, make([]ESNode, 0), scalingHint)
+	require.Equal(t, NONE, scalingOperation.ScalingDirection, scalingOperation.Description)
+	require.Nil(t, scalingOperation.NodeReplicas, scalingOperation.Description)
+}
+
+func TestScaleDownOnHpaResetToOneReplicaWithLowCpu(t *testing.T) {
+	eds := edsTestFixture(10, 1)
+	esIndices := map[string]ESIndex{
+		"ad1": {Replicas: 1, Primaries: 1, Index: "ad1"},
+	}
+	esMSet := buildEDSCpuMetrics(int32(20))
+	as := systemUnderTest(eds, esMSet, nil)
+
+	scalingHint := as.scalingHint()
+	require.Equal(t, DOWN, scalingHint)
+
+	scalingOperation := as.calculateScalingOperation(esIndices, make([]ESNode, 0), scalingHint)
+	require.Equal(t, DOWN, scalingOperation.ScalingDirection, scalingOperation.Description)
+	require.Equal(t, int32(2), *scalingOperation.NodeReplicas, scalingOperation.Description)
+}
+
+func TestNoScalingOnHpaResetToOneReplicaWithModerateCpu(t *testing.T) {
+	eds := edsTestFixture(10, 1)
+	esIndices := map[string]ESIndex{
+		"ad1": {Replicas: 1, Primaries: 1, Index: "ad1"},
+	}
+	esMSet := buildEDSCpuMetrics(int32(35))
+	as := systemUnderTest(eds, esMSet, nil)
+
+	scalingHint := as.scalingHint()
+	require.Equal(t, NONE, scalingHint)
+
+	scalingOperation := as.calculateScalingOperation(esIndices, make([]ESNode, 0), scalingHint)
+	require.Equal(t, NONE, scalingOperation.ScalingDirection, scalingOperation.Description)
+	require.Nil(t, scalingOperation.NodeReplicas, scalingOperation.Description)
+}
+
+func TestScaleIndexReplicasOverNodeReplicasWithHighCpu(t *testing.T) {
+	eds := edsTestFixture(10, 10)
+	eds.Spec.Scaling.MaxReplicas = 15
+	esIndices := map[string]ESIndex{
+		"ad1": {Replicas: 1, Primaries: 1, Index: "ad1"},
+	}
+	esMSet := buildEDSCpuMetrics(int32(65))
+	as := systemUnderTest(eds, esMSet, nil)
+
+	scalingHint := as.scalingHint()
+	require.Equal(t, UP, scalingHint)
+
+	scalingOperation := as.calculateScalingOperation(esIndices, make([]ESNode, 0), scalingHint)
+	require.Equal(t, UP, scalingOperation.ScalingDirection, scalingOperation.Description)
+	require.Equal(t, int32(10), *scalingOperation.NodeReplicas, scalingOperation.Description)
+	require.Equal(t, int32(2), scalingOperation.IndexReplicas[0].Replicas, scalingOperation.Description)
+}
+
+func TestScaleUpAfterReachingMaxIndexReplicas(t *testing.T) {
+	eds := edsTestFixture(4, 4)
+	eds.Spec.Scaling.MaxIndexReplicas = 2
+	eds.Spec.Scaling.MaxReplicas = 10
+	esIndices := map[string]ESIndex{
+		"ad1": {Replicas: 2, Primaries: 1, Index: "ad1"},
+		"ad2": {Replicas: 2, Primaries: 1, Index: "ad2"},
+	}
+	esMSet := buildEDSCpuMetrics(int32(65))
+	as := systemUnderTest(eds, esMSet, nil)
+
+	scalingHint := as.scalingHint()
+	require.Equal(t, UP, scalingHint)
+
+	scalingOperation := as.calculateScalingOperation(esIndices, make([]ESNode, 0), scalingHint)
+	require.Equal(t, NONE, scalingOperation.ScalingDirection, scalingOperation.Description)
+	require.Nil(t, scalingOperation.NodeReplicas, scalingOperation.Description)
+	require.Nil(t, scalingOperation.IndexReplicas, scalingOperation.Description)
 }

--- a/pkg/apis/zalando.org/v1/types.go
+++ b/pkg/apis/zalando.org/v1/types.go
@@ -16,6 +16,7 @@ import (
 // +kubebuilder:printcolumn:name="Desired",type=integer,JSONPath=`.spec.replicas`,description="The desired number of replicas for the stateful set"
 // +kubebuilder:printcolumn:name="Current",type=integer,JSONPath=`.status.replicas`,description="The current number of replicas for the stateful set"
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.hpa_replicas,statuspath=.status.hpa_replicas,selectorpath=.status.selector
 type ElasticsearchDataSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -32,6 +33,10 @@ type ElasticsearchDataSetSpec struct {
 	// zero and not specified. Defaults to 1.
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
+
+	// Number of pods specified by the HPA.
+	// +optional
+	HpaReplicas *int32 `json:"hpa_replicas,omitempty" protobuf:"varint,1,opt,name=hpa_replicas"`
 
 	// Exclude management of System Indices on this Data Set. Defaults to false
 	// +optional
@@ -185,6 +190,12 @@ type ElasticsearchDataSetStatus struct {
 	ObservedGeneration *int64 `json:"observedGeneration,omitempty" protobuf:"varint,1,opt,name=observedGeneration"`
 	// Replicas is the number of Pods by the underlying StatefulSet.
 	Replicas int32 `json:"replicas" protobuf:"varint,2,opt,name=replicas"`
+
+	// HpaReplicas is the number of Pods determined by the HPA metrics.
+	HpaReplicas int32 `json:"hpa_replicas" protobuf:"varint,2,opt,name=hpa_replicas"`
+
+	// Hpa selector
+	Selector string `json:"selector"`
 
 	LastScaleUpStarted   *metav1.Time `json:"lastScaleUpStarted,omitempty"`
 	LastScaleUpEnded     *metav1.Time `json:"lastScaleUpEnded,omitempty"`

--- a/pkg/apis/zalando.org/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/zalando.org/v1/zz_generated.deepcopy.go
@@ -110,6 +110,11 @@ func (in *ElasticsearchDataSetSpec) DeepCopyInto(out *ElasticsearchDataSetSpec) 
 		*out = new(int32)
 		**out = **in
 	}
+	if in.HpaReplicas != nil {
+		in, out := &in.HpaReplicas, &out.HpaReplicas
+		*out = new(int32)
+		**out = **in
+	}
 	in.Template.DeepCopyInto(&out.Template)
 	if in.Scaling != nil {
 		in, out := &in.Scaling, &out.Scaling


### PR DESCRIPTION
# One-line summary

Integrate Horizontal Pod Autoscaler to allow scaling EDS using [ScalingSchedule](https://github.com/zalando-incubator/kube-metrics-adapter#scalingschedule-collectors) custom resource.

## Description
This pr development focusses on using the a scaling schedule or a cluster scaling schedule CRD's for automatically scaling up an EDS to the required number of replicas. The HPA doesn't directly control or edit the replicas of the EDS. The replica count reported by the HPA is stored in a separate property which is taken into account during the calculation for determining the scaling operation.

A new `hpa_replicas` property is introduced to the EDS spec. This property is controlled by the HPA via the [scale subresource](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/_print/#scale-subresource). There is also a corresponding status property. By default the HPA will not set the number of replicas to zero. Therefore the default value of hpa_replicas is 1. The HPA scaling pattern respects the existing cool down periods.

The initial `scalingHint()` method checks for the .spec.hpa_replicas property in addition to the cpu metrics to determine the next scaling operation. 

The subsequent `scaleUpOrDown` has the core logic for incorporating the hpa replica count to calculate the next change in index or node replicas. 

- There will be no scaling operation if scaling is disabled.
- There will be no scaling operation if there are no indices to manage.
- `MinNodeReplica` condition is satisfied first. The hpa replica count is satisfied in the next scaling step.
- `MaxShardsPerNode` is satisfied before satisfying hpa replica count. The hpa replica count maybe satisfied in the next scaling step.
- `MinIndexReplicas` is satisfied before satisfying hpa replica count. The hpa replica count is satisfied in the next scaling step.
- For scaling hint `UP`:
  - Preserve the shard to node ratio by increasing index replicas only after the hpa replica count (> 1) has been satisfied. This step prevents the need or desire to maintain the same shard to node ratio until reaching the hpa replica count. This also might add a downside of skewed shard to node ratio when the hpa replica count is satisfied. This step can be revisited to preserve equal shard to node ratio or the `MinShardsPerNode` condition. 
  - As before calculate the new desired node replicas by reducing the shard to node ratio 1.
  - If hpa replica count is higher than the new node replica count in the previous step then scale up directly to hpa replica count. This step can lead to skew in shard to node ratio.
  - The last step is to scale up to newly calculated node replicas based on the 
- For scaling hint `DOWN`:
  - Scale down index replicas if index replicas is > `MinIndexReplica` setting. Re-calculate the number of node replicas based on the new shard to node ratio.

A custom metrics adapter like [kube-metrics-adapter](https://github.com/zalando-incubator/kube-metrics-adapter) is required to support the custom [ScheduledScaling CRD](https://github.com/zalando-incubator/kube-metrics-adapter#scalingschedule-collectors). The custom metrics server is responsible for collecting replica counts or scaling values based on the CRD.

## Types of Changes
- New feature (non-breaking change which adds functionality)
- Refactor/improvements
- Documentation / non-code

## Tasks
_List of tasks you will do to complete the PR_
  - [ ] Improvements to scale up in steps instead of a single step scale up to satisfy hpa replica count.
  - [ ] Add tests for EDS status updates.
  - [ ] Update e2e tests.
  - [ ] Update the getting started section.
  - [ ] Add debug notes or links to test the hpa and the scale sub resource.

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
- Verify the custom metrics server RBAC setup before testing the scheduled scaling. Link to the debugging section.
