### PR TITLE
Abortable scale-down

### DIFF
--- a/operator/elasticsearch.go
+++ b/operator/elasticsearch.go
@@ -609,6 +609,10 @@ func (r *EDSResource) Get(ctx context.Context) (StatefulResource, error) {
 		return nil, err
 	}
 
+	// set TypeMeta manually because of this bug:
+	// https://github.com/kubernetes/client-go/issues/308
+	newEds.Kind = r.Kind()
+	newEds.APIVersion = r.APIVersion()
 	sr := &EDSResource{
 		eds:      newEds,
 		kube:     r.kube,

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -468,7 +468,7 @@ func (o *Operator) rescaleStatefulSet(ctx context.Context, sts *appsv1.StatefulS
 			}
 			newDesiredReplicas := int(newSR.Replicas())
 			if newDesiredReplicas > desiredReplicas {
-				log.Infof("EDS %s/%s target scaling definition changed from %d to %d, aborting scale-down", sr.Namespace(), sr.Name(), desiredReplicas, newDesiredReplicas)
+				log.Infof("EDS %s/%s target scaling definition changed from %d to %d, aborting scale-down", newSR.Namespace(), newSR.Name(), desiredReplicas, newDesiredReplicas)
 				return nil
 			}
 
@@ -485,7 +485,7 @@ func (o *Operator) rescaleStatefulSet(ctx context.Context, sts *appsv1.StatefulS
 			}
 
 			log.Infof("Draining Pod %s/%s for scaledown", pod.Namespace, pod.Name)
-			err = sr.Drain(ctx, &pod)
+			err = newSR.Drain(ctx, &pod)
 			if err != nil {
 				return fmt.Errorf("failed to drain pod %s/%s: %v", pod.Namespace, pod.Name, err)
 			}

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -459,6 +459,7 @@ func (o *Operator) rescaleStatefulSet(ctx context.Context, sts *appsv1.StatefulS
 	}
 
 	if len(pods.Items) > replicas {
+		log.Infof("Starting pod draining from %d to %d pods", len(pods.Items), replicas)
 		for _, pod := range pods.Items[replicas:] {
 			// if pod is Pending we don't need to safely drain it.
 			if pod.Status.Phase == v1.PodPending {

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -485,7 +485,7 @@ func (o *Operator) rescaleStatefulSet(ctx context.Context, sts *appsv1.StatefulS
 				return fmt.Errorf("failed to refresh EDS: %v", err)
 			}
 			newDesiredReplicas := int(newSR.Replicas())
-			if newDesiredReplicas != desiredReplicas {
+			if newDesiredReplicas > desiredReplicas {
 				log.Infof("EDS %s/%s target scaling definition changed from %d to %d, aborting scale-down", sr.Namespace(), sr.Name(), desiredReplicas, newDesiredReplicas)
 				return nil
 			}

--- a/operator/operator_test.go
+++ b/operator/operator_test.go
@@ -49,6 +49,7 @@ func (r *mockResource) UpdateStatus(ctx context.Context, sts *appsv1.StatefulSet
 func (r *mockResource) PreScaleDownHook(ctx context.Context) error                      { return nil }
 func (r *mockResource) OnStableReplicasHook(ctx context.Context) error                  { return nil }
 func (r *mockResource) Drain(ctx context.Context, pod *v1.Pod) error                    { return nil }
+func (r *mockResource) Get(ctx context.Context) (StatefulResource, error)               { return r, nil }
 
 func TestPrioritizePodsForUpdate(t *testing.T) {
 	updatingPod := v1.Pod{

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.


### PR DESCRIPTION
# One-line summary

The ES Operator could decide to scale down, but while scaling down the thresholds for scale up are being exceeded, e.g. if we're reaching a point where we should stop scaling down.

## References

Issue : #57 

## Description

Introduces StatefulResourceGetter interface to allow refreshing of an EDS during scaling, which happens in case the autoscaler indicated a scale-up.

## Types of Changes

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)

