### PR TITLE
Docker: use "alpine-3" as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/library/alpine-3.13:latest
+FROM registry.opensource.zalan.do/library/alpine-3:latest
 LABEL maintainer="Team Lens @ Zalando SE <team-lens@zalando.de>"
 
 # add binary

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/library/alpine-3.13:latest
+FROM registry.opensource.zalan.do/library/alpine-3:latest
 LABEL maintainer="Team Lens @ Zalando SE <team-lens@zalando.de>"
 
 # add binary


### PR DESCRIPTION
Make es-operator compliant again by migrating to the alpine-3 base image.
