### PR TITLE
Bugfix: Allow scale-down when at one-shard-per-node

### DIFF
--- a/cmd/e2e/test_utils.go
+++ b/cmd/e2e/test_utils.go
@@ -274,10 +274,12 @@ func waitForSTSCondition(t *testing.T, stsName string, conditions ...func(sts *a
 
 func createEDS(name string, spec zv1.ElasticsearchDataSetSpec) error {
 	myspec := spec.DeepCopy()
-	myspec.Template.Spec.Containers[0].Env = append(myspec.Template.Spec.Containers[0].Env, v1.EnvVar{
-		Name:  "node.attr.group",
-		Value: name,
-	})
+	for i, env := range myspec.Template.Spec.Containers[0].Env {
+		if env.Name == "node.attr.group" {
+			myspec.Template.Spec.Containers[0].Env[i].Value = name
+			break
+		}
+	}
 	eds := &zv1.ElasticsearchDataSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/e2e.sh
+++ b/e2e.sh
@@ -2,7 +2,7 @@
 
 # Simple script for running the e2e test from your local development machine
 # against "some" cluster.
-# You need to run `kubectl proxy` in a different terminat before running the
+# You need to run `kubectl proxy` in a different terminal before running the
 # script.
 
 NAMESPACE="${NAMESPACE:-"es-operator-e2e-$(date +%s)"}"

--- a/operator/autoscaler.go
+++ b/operator/autoscaler.go
@@ -382,10 +382,8 @@ func shardToNodeRatio(shards, nodes int32) float64 {
 }
 
 func calculateNodesWithSameShardToNodeRatio(currentDesiredNodeReplicas, currentTotalShards, newTotalShards int32) int32 {
-	currentShardToNodeRatio := shardToNodeRatio(currentTotalShards, currentDesiredNodeReplicas)
-	if currentShardToNodeRatio <= 1 {
-		return currentDesiredNodeReplicas
-	}
+	// reconcile shardToNodeRatio to not become below 1
+	currentShardToNodeRatio := math.Max(shardToNodeRatio(currentTotalShards, currentDesiredNodeReplicas), 1)
 	return int32(math.Ceil(float64(newTotalShards) / float64(currentShardToNodeRatio)))
 }
 


### PR DESCRIPTION
## One-line summary

Issue: Due to a wrong edge-case handling, when hitting a one-shard-per-node setup, the es-operator will not scale-down further.

Closes https://github.com/zalando-incubator/es-operator/issues/398 

## Description

There have been reports of es-operator being stuck during scale-down. It happens in this situation:

- At maximum scaling we have one-shard-per-node
- There is a scaling hint "DOWN" that doesn't execute, as the edge-case of having less than one shard per node (which was meant to avoid over-scaling at scale-up) is triggered.

## Changes

- Instead of stopping the scaling, ensure that the scaling respects a minimum value of one-shard-per-node.
- Fixes the e2e test which were failing due to duplicate env variable

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
