### PR TITLE
Fix team assignment in zappr

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -6,5 +6,5 @@ approvals:
       from:
         orgs:
           - "zalando"
-X-Zalando-Team: poirot
+X-Zalando-Team: pandora
 X-Zalando-Type: code


### PR DESCRIPTION
# One-line summary

Fixes the "invalid team" warning appearing with every PR.


