### PR TITLE
Removes Trivy from the project

### DIFF
--- a/.github/workflows/docker-multiarch.yaml
+++ b/.github/workflows/docker-multiarch.yaml
@@ -100,15 +100,3 @@ jobs:
           echo "image-ref=${IMAGE_REF}" >> $GITHUB_OUTPUT
           echo "Using image reference: ${IMAGE_REF}"
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ steps.image-ref.outputs.image-ref }}
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'

--- a/docs/MULTIARCH_BUILD.md
+++ b/docs/MULTIARCH_BUILD.md
@@ -15,8 +15,7 @@ The repository includes a GitHub Actions workflow (`.github/workflows/docker-mul
 1. **Builds multiarch binaries** for both amd64 and arm64
 2. **Creates and pushes Docker images** to `ghcr.io/<owner>/<repo>`
 3. **Handles authentication** using the built-in `GITHUB_TOKEN`
-4. **Scans images for vulnerabilities** using Trivy
-5. **Supports multiple triggers**:
+4. **Supports multiple triggers**:
    - Push to `master`/`main` branch
    - Git tags (releases)
    - Pull requests (build only, no push)
@@ -121,7 +120,6 @@ gh auth token | docker login ghcr.io -u <username> --password-stdin
 ## Security
 
 The workflow includes:
-- **Vulnerability scanning** with Trivy
 - **Minimal permissions** using GitHub's built-in tokens
 - **SARIF upload** for security findings in GitHub Security tab
 - **Cache optimization** for faster builds


### PR DESCRIPTION
# One-line summary

[Trivy was compromised](https://www.docker.com/blog/trivy-supply-chain-compromise-what-docker-hub-users-should-know/). Remove it from the project. 

## Description

We have internal artifact scanning, Trivy is not needed for es-operator.

## Types of Changes

- Configuration change
- Documentation / non-code
